### PR TITLE
Feat: Add advanced severity for notification rules

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -1111,9 +1111,12 @@ class Backend(Database):
             'receivers': notification_rule.receivers,
             'useOnCall': notification_rule.use_oncall,
             'channelId': notification_rule.channel_id,
+            'useAdvancedSeverity': notification_rule.use_advanced_severity,
         }
         if notification_rule.severity:
             data['severity'] = notification_rule.severity
+        if notification_rule.advanced_severity:
+            data['advancedSeverity'] = [n.serialize for n in notification_rule.advanced_severity]
         if notification_rule.days:
             data['days'] = notification_rule.days
         if notification_rule.user:
@@ -1163,7 +1166,8 @@ class Backend(Database):
             {'$or': [{'startTime': None}, {'startTime': {'$lte': alert.time.hour + alert.time.minute / 100}}]},
             {'$or': [{'endTime': None}, {'endTime': {'$gt': alert.time.hour + alert.time.minute / 100}}]},
             {'$or': [{'days': None}, {'days': []}, {"days": {'$in': [alert.day]}}]},
-            {'$or': [{'severity': None}, {'severity': []}, {'severity': {'$in': [alert.severity]}}]},
+            {'$or': [{'useAdvancedSeverity': True}, {'severity': None}, {'severity': []}, {'severity': {'$in': [alert.severity]}}]},
+            {'$or': [{'useAdvancedSeverity': False}, {'$and': [{'$or': [{'advancedSeverity.from': []}, {'advancedSeverity.from': {'$in': [alert.previous_severity]}}]}, {'$or': [{'advancedSeverity.to': []}, {'advancedSeverity.to': {'$in': [alert.severity]}}]}]}]},
             {'$or': [{'resource': None}, {'resource': alert.resource}]},
             {"$or": [{"service": None}, {'service': {'$not': {'$elemMatch': {'$nin': alert.service}}}}]},
             {'$or': [{'event': None}, {'event': alert.event}]},

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -53,6 +53,24 @@ class HistoryAdapter:
         return str(self.getquoted())
 
 
+class AdvancedSeverityAdapter:
+    def __init__(self, advanced_severity) -> None:
+        self.advanced_severity = advanced_severity
+        self.conn = None
+
+    def prepare(self, conn):
+        self.conn = conn
+
+    def getquoted(self):
+        def quoted(o):
+            a = adapt(o)
+            if hasattr(a, 'prepare'):
+                a.prepare(self.conn)
+            return a.getquoted().decode('utf-8')
+
+        return f'({quoted(self.advanced_severity.from_)},{quoted(self.advanced_severity.to)})::severity_advanced'
+
+
 Record = namedtuple('Record', [
     'id', 'resource', 'event', 'environment', 'severity', 'status', 'service',
     'group', 'value', 'text', 'tags', 'attributes', 'origin', 'update_time',
@@ -80,8 +98,11 @@ class Backend(Database):
             conn,
             globally=True
         )
+        register_composite('severity_advanced', conn, globally=True)
         from alerta.models.alert import History
+        from alerta.models.notification_rule import AdvancedSeverity
         register_adapter(History, HistoryAdapter)
+        register_adapter(AdvancedSeverity, AdvancedSeverityAdapter)
 
     def connect(self):
         retry = 0
@@ -950,9 +971,9 @@ class Backend(Database):
     def create_notification_rule(self, notification_rule):
         insert = """
             INSERT INTO notification_rules (id, priority, environment, service, resource, event, "group", tags,
-                customer, "user", create_time, start_time, end_time, days, receivers, use_oncall, severity, text, channel_id)
+                customer, "user", create_time, start_time, end_time, days, receivers, use_oncall, severity, text, channel_id, advanced_severity, use_advanced_severity)
             VALUES (%(id)s, %(priority)s, %(environment)s, %(service)s, %(resource)s, %(event)s, %(group)s, %(tags)s,
-                %(customer)s, %(user)s, %(create_time)s, %(start_time)s, %(end_time)s, %(days)s, %(receivers)s, %(use_oncall)s, %(severity)s, %(text)s, %(channel_id)s)
+                %(customer)s, %(user)s, %(create_time)s, %(start_time)s, %(end_time)s, %(days)s, %(receivers)s, %(use_oncall)s, %(severity)s, %(text)s, %(channel_id)s, %(advanced_severity)s::severity_advanced[], %(use_advanced_severity)s )
             RETURNING *
         """
         return self._insert(insert, vars(notification_rule))
@@ -992,12 +1013,13 @@ class Backend(Database):
 
     def get_notification_rules_active(self, alert):
         select = """
-            SELECT *
-            FROM notification_rules
+            SELECT * from (select *, generate_subscripts(advanced_severity,1) as s 
+            FROM notification_rules) as foo
             WHERE (start_time IS NULL OR start_time <= %(time)s) AND (end_time IS NULL OR end_time > %(time)s)
               AND (days='{}' OR ARRAY[%(day)s] <@ days)
               AND environment=%(environment)s
-              AND (severity='{}' OR ARRAY[%(severity)s] <@ severity)
+              AND (use_advanced_severity=TRUE OR severity='{}' OR ARRAY[%(severity)s] <@ severity)
+              AND (use_advanced_severity=FALSE OR ((advanced_severity[s].from_='{}' OR ARRAY[%(previous_severity)s] <@ advanced_severity[s].from_) AND (advanced_severity[s].to='{}' OR ARRAY[%(severity)s] <@ advanced_severity[s].to)))
               AND (resource IS NULL OR resource=%(resource)s)
               AND (service='{}' OR service <@ %(service)s)
               AND (event IS NULL OR event=%(event)s)

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -144,7 +144,19 @@ DO $$
 BEGIN
     ALTER TABLE notification_channels ADD COLUMN "host" text;
 EXCEPTION
-    WHEN duplicate_column THEN RAISE NOTICE 'column "host" already exists in notification_rules.';
+    WHEN duplicate_column THEN RAISE NOTICE 'column "host" already exists in notification_channels.';
+END$$;
+
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'severity_advanced') THEN
+        CREATE TYPE severity_advanced AS (
+            "from_" text[],
+            "to" text[]
+        );
+    END IF;
+
 END$$;
 
 CREATE TABLE IF NOT EXISTS notification_rules (
@@ -171,6 +183,13 @@ CREATE TABLE IF NOT EXISTS notification_rules (
 DO $$
 BEGIN
     ALTER TABLE notification_rules ADD COLUMN use_oncall boolean;
+EXCEPTION
+    WHEN duplicate_column THEN RAISE NOTICE 'column "use_on_call" already exists in notification_rules.';
+END$$;
+DO $$
+BEGIN
+    ALTER TABLE notification_rules ADD COLUMN advanced_severity severity_advanced[];
+    ALTER TABLE notification_rules ADD COLUMN use_advanced_severity boolean;
 EXCEPTION
     WHEN duplicate_column THEN RAISE NOTICE 'column "use_on_call" already exists in notification_rules.';
 END$$;

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -189,9 +189,15 @@ END$$;
 DO $$
 BEGIN
     ALTER TABLE notification_rules ADD COLUMN advanced_severity severity_advanced[];
+EXCEPTION
+    WHEN duplicate_column THEN RAISE NOTICE 'column "advanced_severity" already exists in notification_rules.';
+END$$;
+
+DO $$
+BEGIN
     ALTER TABLE notification_rules ADD COLUMN use_advanced_severity boolean;
 EXCEPTION
-    WHEN duplicate_column THEN RAISE NOTICE 'column "use_on_call" already exists in notification_rules.';
+    WHEN duplicate_column THEN RAISE NOTICE 'column "use_advanced_severity" already exists in notification_rules.';
 END$$;
 
 CREATE TABLE IF NOT EXISTS on_calls(

--- a/alerta/views/notification_rules.py
+++ b/alerta/views/notification_rules.py
@@ -78,10 +78,10 @@ def get_notification_rule(notification_rule_id):
 @jsonp
 def get_notification_rules_active():
     alert_json = request.json
-    if alert_json == None or alert_json.get("duplicateCount"):
+    if alert_json == None or alert_json.get("id") == None:
         return jsonify(status="ok", total=0, notificationRules=[])
     try:
-        alert = Alert.parse(alert_json)
+        alert = Alert.find_by_id(alert_json.get("id"))
     except Exception as e:
         raise ApiError(str(e), 400)
 

--- a/tests/test_notification_rule.py
+++ b/tests/test_notification_rule.py
@@ -792,3 +792,146 @@ class NotificationRuleTestCase(unittest.TestCase):
         self.assertEqual(data["message"], "not found")
 
         self.delete_api_obj("/notificationrules/" + notification_rule_id, self.headers)
+
+    def test_advanced_severity(self):
+
+        all = {
+            "environment": "Production",
+            "channelId": "SMS_Channel",
+            "receivers": [],
+            "useAdvancedSeverity": True,
+            "text": "administartively sms",
+        }
+        simple = {
+            **all,
+            "useAdvancedSeverity": False,
+            "severity": ["critical", "major"]
+        }
+        to_critical_major_from_all = {
+            **all,
+            "advancedSeverity": [{"from": [], "to":["major", "critical"]}],
+        }
+        to_normal_from_critical_major = {
+            **all,
+            "advancedSeverity": [{"from": ["major", "critical"], "to":["normal"]}],
+        }
+        alert_base = {
+            "environment": "Production",
+            "resource": "notification_net",
+            "event": "notification_down",
+            "severity": "normal",
+            "service": ["Core", "Web", "Network"],
+            "group": "Network",
+            "tags": ["notification_test", "network"],
+        }
+
+        self.create_api_obj("/alert", alert_base, self.headers)
+
+        channel_data = self.create_api_obj("/notificationchannels", self.sms_channel, self.headers)
+        data = self.get_api_obj("/notificationchannels", self.headers)
+        self.assertIn(channel_data["notificationChannel"], data["notificationChannels"])
+
+        data = self.create_api_obj("/notificationrules", all, self.headers)
+        notification_rule = data["notificationRule"]
+        data = self.create_api_obj("/notificationrules", to_critical_major_from_all, self.headers)
+        to_critical_major_from_all_rule = data["notificationRule"]
+        data = self.create_api_obj("/notificationrules", to_normal_from_critical_major, self.headers)
+        to_normal_from_critical_major_rule = data["notificationRule"]
+        data = self.create_api_obj("/notificationrules", simple, self.headers)
+        simple_rule = data["notificationRule"]
+
+        all_notifications_rules = self.get_api_obj("/notificationrules", self.headers)["notificationRules"]
+        self.assertIn(notification_rule, all_notifications_rules)
+        self.assertIn(to_critical_major_from_all_rule, all_notifications_rules)
+        self.assertIn(to_normal_from_critical_major_rule, all_notifications_rules)
+        self.assertIn(simple_rule, all_notifications_rules)
+
+        alert_base["severity"] = 'major'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertNotIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertIn(simple_rule, active_notification_rules)
+
+        alert_base["severity"] = 'normal'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertNotIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertNotIn(simple_rule, active_notification_rules)
+
+        alert_base["severity"] = 'critical'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertNotIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertIn(simple_rule, active_notification_rules)
+
+        alert_base["severity"] = 'normal'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertNotIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertNotIn(simple_rule, active_notification_rules)
+
+        alert_base["severity"] = 'informational'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertNotIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertNotIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertNotIn(simple_rule, active_notification_rules)
+
+        alert_base["severity"] = 'normal'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertNotIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertNotIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertNotIn(simple_rule, active_notification_rules)
+
+        alert_base["severity"] = 'informational'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertNotIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertNotIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertNotIn(simple_rule, active_notification_rules)
+
+        alert_base["severity"] = 'critical'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertNotIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertIn(simple_rule, active_notification_rules)
+
+        alert_base["severity"] = 'informational'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertNotIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertNotIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertNotIn(simple_rule, active_notification_rules)
+
+        alert_base["severity"] = 'major'
+        alert = self.create_api_obj("/alert", alert_base, self.headers)["alert"]
+        active_notification_rules = self.create_api_obj("/notificationrules/active", alert, self.headers, 200)["notificationRules"]
+
+        self.assertIn(notification_rule, active_notification_rules)
+        self.assertIn(to_critical_major_from_all_rule, active_notification_rules)
+        self.assertNotIn(to_normal_from_critical_major_rule, active_notification_rules)
+        self.assertIn(simple_rule, active_notification_rules)

--- a/tests/test_on_call.py
+++ b/tests/test_on_call.py
@@ -281,7 +281,6 @@ class OnCallTestCase(unittest.TestCase):
         day_plus_fail = now + timedelta(days=1)
         now_minus_fail = datetime(now.year, now.month - 1, 28) if now.month > 1 else datetime(now.year - 1, 12, 28)
         now_plus_fail = datetime(now.year, now.month + 1, 28) if now.month < 12 else datetime(now.year + 1, 1, 28)
-        print(now_minus_fail, now_plus_fail, now)
         now_week = now.isocalendar()[1]
         now_minus_fail_week = now_week - 1 if now_week > 1 else 52
         now_plus_fail_week = now_week + 1 if now_week < 52 else 1


### PR DESCRIPTION
With advanced severity, you can decide which severity the alert had compared to what it has. Alerta can send a notification when an alert goes from critical to normal and not send an alert when it goes from minor to normal.

notification_rule with advanced severity:
```json
{
    "environment": "Production",
    "channelId": "SMS_Channel",
    "receivers": [],
    "useAdvancedSeverity": true,
    "text": "administartively SMS",
    "advancedSeverity": [
        {
            "from": [
                "major",
                "critical"
            ],
            "to": [
                "normal"
            ]
        },
        {
            "from": [],
            "to": [
                "major",
                "critical"
            ]
        }
    ]
}
```
Assigning the from or the to field to an empty array means all severity. The second advanced severity in the rule above will fire notification whenever an alert goes from any severity to major or critical.