### PR TITLE
fix: remove null variables from excluded_tags

### DIFF
--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -286,6 +286,7 @@ BEGIN
     UPDATE public.notification_rules SET resource=NULL WHERE resource='';
     UPDATE public.notification_rules SET event=NULL WHERE event='';
     UPDATE public.notification_rules SET "group"=NULL WHERE "group"='';
+    UPDATE notification_rules SET excluded_tags='{}' WHERE excluded_tags IS NULL;
 
 END$$;
 


### PR DESCRIPTION
**Description**
Add schema script that removes null variables from excluded_tags for notification rules.

Fixes #102 

**Changes**
- update all excluded_tags in notification rules to an empty array where excluded_tags is null 

