### PR TITLE
fix: return count of notification history instead of count of notific…

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1340,7 +1340,7 @@ class Backend(Database):
     def get_notifications_history_count(self, query=None):
         query = query or Query()
         select = """
-            SELECT COUNT(1) FROM notification_groups
+            SELECT COUNT(1) FROM notification_history
              WHERE {where}
         """.format(
             where=query.where
@@ -1349,7 +1349,7 @@ class Backend(Database):
 
     def confirm_notification_history(self, id):
         update = """
-            UPDATE notification_groups
+            UPDATE notification_history
             SET confirmed=true, confirmed_time=%(time)s
             WHERE id=%(id)s
             RETURNING *


### PR DESCRIPTION
**Description**
Fix query for requesting count of notification history to return the count of notification history instead of returning the count of notification group

**Changes**
- change notification group to notification history in the database query for notification history count
- change notification group to notification history in the database query for confirming notification history