### PR TITLE
Feat: add edit of email when using ldap

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -127,8 +127,10 @@ def login():
         user = User(name=name, login=login, password='', email=email,
                     roles=current_app.config['USER_ROLES'], text='LDAP user', email_verified=email_verified)
         user = user.create()
-    else:
+    elif not current_app.config.get("LDAP_ALLOW_EMAIL_EDIT"):
         user.update(login=login, email=email, email_verified=email_verified)
+    else:
+        user.update(login=login)
 
     if ldap_bind_username:
         try:

--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -127,7 +127,7 @@ def login():
         user = User(name=name, login=login, password='', email=email,
                     roles=current_app.config['USER_ROLES'], text='LDAP user', email_verified=email_verified)
         user = user.create()
-    elif not current_app.config.get("LDAP_ALLOW_EMAIL_EDIT"):
+    elif not current_app.config.get('LDAP_ALLOW_EMAIL_EDIT'):
         user.update(login=login, email=email, email_verified=email_verified)
     else:
         user.update(login=login)

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -135,6 +135,7 @@ LDAP_GROUP_NAME_ATTR = 'dn'  # eg. dn, memberOf, or cn
 LDAP_DEFAULT_DOMAIN = ''  # if set allows users to login with bare username
 LDAP_CONFIG = {}  # type: Dict[str, Any]
 ALLOWED_LDAP_GROUPS = ['*']
+LDAP_ALLOW_EMAIL_EDIT = True
 
 # Microsoft Identity Platform (v2.0)
 AZURE_TENANT = 'common'  # "common", "organizations", "consumers" or tenant ID

--- a/alerta/utils/config.py
+++ b/alerta/utils/config.py
@@ -66,6 +66,7 @@ class Config:
             config['ALLOWED_OIDC_ROLES'] = get_config('ALLOWED_KEYCLOAK_ROLES', default=[], type=list, config=config)
 
         config['LDAP_BIND_PASSWORD'] = get_config('LDAP_BIND_PASSWORD', default=None, type=str, config=config)
+        config['LDAP_ALLOW_EMAIL_EDIT'] = get_config('LDAP_ALLOW_EMAIL_EDIT', default=True, type=str, config=config)
 
         config['OIDC_ISSUER_URL'] = get_config('OIDC_ISSUER_URL', default=None, type=str, config=config)
         config['ALLOWED_OIDC_ROLES'] = get_config('ALLOWED_OIDC_ROLES', default=[], type=list, config=config)

--- a/alerta/views/config.py
+++ b/alerta/views/config.py
@@ -22,6 +22,7 @@ def config():
                 'previous_severity': alarm_model.DEFAULT_PREVIOUS_SEVERITY
             }
         },
+        'ldap_email_edit': current_app.config['LDAP_ALLOW_EMAIL_EDIT'],
         'auth_required': current_app.config['AUTH_REQUIRED'],
         'delete_alert_scope_enforced': 'delete:alerts' in current_app.config['DELETE_SCOPES'],
         'allow_readonly': current_app.config['ALLOW_READONLY'],


### PR DESCRIPTION
**Description**
Add a setting to enable editing of users' email addresses when using LDAP.

**Changes**
- add LDAP_ALLOW_EMAIL_EDIT with default to true to settings
- add LDAP_ALLOW_EMAIL_EDIT environment variable
- disable update of email and email_verified during LDAP login when LDAP_ALLOW_EMAIL_EDIT is set to True

