### PR TITLE
Refac: rename advanced severity to triggers

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -68,7 +68,7 @@ class AdvancedSeverityAdapter:
                 a.prepare(self.conn)
             return a.getquoted().decode('utf-8')
 
-        return f'({quoted(self.advanced_severity.from_)},{quoted(self.advanced_severity.to)})::severity_advanced'
+        return f'({quoted(self.advanced_severity.from_)},{quoted(self.advanced_severity.to)},{quoted(self.advanced_severity.text)})::severity_advanced'
 
 
 Record = namedtuple('Record', [

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1122,9 +1122,9 @@ class Backend(Database):
               AND (days='{}' OR ARRAY[%(day)s] <@ days)
               AND environment=%(environment)s
               AND (
-                    (triggers[s].from_severity='{}' OR ARRAY[%(previous_severity)s] <@ triggers[s].from_severity)
-                    AND (triggers[s].to_severity='{}' OR ARRAY[%(severity)s] <@ triggers[s].to_severity)
-                    AND (triggers[s].status='{}' OR ARRAY[%(status)s] <@ triggers[s].status)
+                    (triggers[s].from_severity='{}' OR triggers[s].from_severity IS NULL OR ARRAY[%(previous_severity)s] <@ triggers[s].from_severity)
+                    AND (triggers[s].to_severity='{}' OR triggers[s].to_severity IS NULL OR ARRAY[%(severity)s] <@ triggers[s].to_severity)
+                    AND (triggers[s].status='{}' OR triggers[s].status IS NULL OR ARRAY[%(status)s] <@ triggers[s].status)
                 )
               AND (resource IS NULL OR resource=%(resource)s)
               AND (service='{}' OR service <@ %(service)s)

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -53,9 +53,9 @@ class HistoryAdapter:
         return str(self.getquoted())
 
 
-class AdvancedSeverityAdapter:
-    def __init__(self, advanced_severity) -> None:
-        self.advanced_severity = advanced_severity
+class NotificationTriggersAdapter:
+    def __init__(self, notification_triggers) -> None:
+        self.triggers = notification_triggers
         self.conn = None
 
     def prepare(self, conn):
@@ -68,7 +68,7 @@ class AdvancedSeverityAdapter:
                 a.prepare(self.conn)
             return a.getquoted().decode('utf-8')
 
-        return f'({quoted(self.advanced_severity.from_)},{quoted(self.advanced_severity.to)},{quoted(self.advanced_severity.text)})::severity_advanced'
+        return f'({quoted(self.triggers.from_severity)},{quoted(self.triggers.to_severity)}, {quoted(self.triggers.status)},{quoted(self.triggers.text)})::notification_triggers'
 
 
 Record = namedtuple('Record', [
@@ -105,11 +105,11 @@ class Backend(Database):
             conn,
             globally=True
         )
-        register_composite('severity_advanced', conn, globally=True)
+        register_composite('notification_triggers', conn, globally=True)
         from alerta.models.alert import History
-        from alerta.models.notification_rule import AdvancedSeverity
+        from alerta.models.notification_rule import NotificationTriggers
         register_adapter(History, HistoryAdapter)
-        register_adapter(AdvancedSeverity, AdvancedSeverityAdapter)
+        register_adapter(NotificationTriggers, NotificationTriggersAdapter)
 
     def connect(self):
         retry = 0
@@ -1075,10 +1075,10 @@ class Backend(Database):
 
     def create_notification_rule(self, notification_rule):
         insert = """
-            INSERT INTO notification_rules (id, name, active, priority, environment, service, resource, event, "group", tags, status, reactivate, excluded_tags, delay_time,
-                customer, "user", create_time, start_time, end_time, days, receivers, user_ids, group_ids, use_oncall, severity, text, channel_id, advanced_severity, use_advanced_severity)
-            VALUES (%(id)s, %(name)s, %(active)s, %(priority)s, %(environment)s, %(service)s, %(resource)s, %(event)s, %(group)s, %(tags)s, %(status)s, %(reactivate)s, %(excluded_tags)s, %(delay_time)s,
-                %(customer)s, %(user)s, %(create_time)s, %(start_time)s, %(end_time)s, %(days)s, %(receivers)s, %(user_ids)s, %(group_ids)s, %(use_oncall)s, %(severity)s, %(text)s, %(channel_id)s, %(advanced_severity)s::severity_advanced[], %(use_advanced_severity)s )
+            INSERT INTO notification_rules (id, name, active, priority, environment, service, resource, event, "group", tags, reactivate, excluded_tags, delay_time,
+                customer, "user", create_time, start_time, end_time, days, receivers, user_ids, group_ids, use_oncall, text, channel_id, triggers)
+            VALUES (%(id)s, %(name)s, %(active)s, %(priority)s, %(environment)s, %(service)s, %(resource)s, %(event)s, %(group)s, %(tags)s, %(reactivate)s, %(excluded_tags)s, %(delay_time)s,
+                %(customer)s, %(user)s, %(create_time)s, %(start_time)s, %(end_time)s, %(days)s, %(receivers)s, %(user_ids)s, %(group_ids)s, %(use_oncall)s, %(text)s, %(channel_id)s, %(triggers)s::notification_triggers[] )
             RETURNING *
         """
         return self._insert(insert, vars(notification_rule))
@@ -1116,20 +1116,22 @@ class Backend(Database):
 
     def get_notification_rules_active(self, alert):
         select = """
-            SELECT * from (select *, generate_subscripts(advanced_severity,1) as s
+            SELECT * from (select *, generate_subscripts(triggers,1) as s
             FROM notification_rules) as foo
             WHERE (start_time IS NULL OR start_time <= %(time)s) AND (end_time IS NULL OR end_time > %(time)s)
               AND (days='{}' OR ARRAY[%(day)s] <@ days)
               AND environment=%(environment)s
-              AND (use_advanced_severity=TRUE OR severity='{}' OR ARRAY[%(severity)s] <@ severity)
-              AND (use_advanced_severity=FALSE OR ((advanced_severity[s].from_='{}' OR ARRAY[%(previous_severity)s] <@ advanced_severity[s].from_) AND (advanced_severity[s].to='{}' OR ARRAY[%(severity)s] <@ advanced_severity[s].to)))
+              AND (
+                    (triggers[s].from_severity='{}' OR ARRAY[%(previous_severity)s] <@ triggers[s].from_severity)
+                    AND (triggers[s].to_severity='{}' OR ARRAY[%(severity)s] <@ triggers[s].to_severity)
+                    AND (triggers[s].status='{}' OR ARRAY[%(status)s] <@ triggers[s].status)
+                )
               AND (resource IS NULL OR resource=%(resource)s)
               AND (service='{}' OR service <@ %(service)s)
               AND (event IS NULL OR event=%(event)s)
               AND ("group" IS NULL OR "group"=%(group)s)
               AND (tags='{}' OR tags <@ %(tags)s)
               AND (excluded_tags='{}' OR NOT excluded_tags <@ %(tags)s)
-              AND (status='{}' OR ARRAY[%(status)s] <@ status)
               AND active=true
         """
         if current_app.config['CUSTOMER_VIEWS']:
@@ -1147,20 +1149,22 @@ class Backend(Database):
 
     def get_notification_rules_active_status(self, alert, status):
         select = """
-            SELECT * from (select *, generate_subscripts(advanced_severity,1) as s
+            SELECT * from (select *, generate_subscripts(triggers,1) as s
             FROM notification_rules) as foo
             WHERE (start_time IS NULL OR start_time <= %(time)s) AND (end_time IS NULL OR end_time > %(time)s)
               AND (days='{}' OR ARRAY[%(day)s] <@ days)
               AND environment=%(environment)s
-              AND (use_advanced_severity=TRUE OR severity='{}' OR ARRAY[%(severity)s] <@ severity)
-              AND (use_advanced_severity=FALSE OR ((advanced_severity[s].from_='{}' OR ARRAY[%(previous_severity)s] <@ advanced_severity[s].from_) AND (advanced_severity[s].to='{}' OR ARRAY[%(severity)s] <@ advanced_severity[s].to)))
+              AND (
+                    (triggers[s].from_severity='{}' OR ARRAY[%(previous_severity)s] <@ triggers[s].from_severity)
+                    AND (triggers[s].to_severity='{}' OR ARRAY[%(severity)s] <@ triggers[s].to_severity)
+                    AND (ARRAY[%(status)s] <@ triggers[s].status)
+                )
               AND (resource IS NULL OR resource=%(resource)s)
               AND (service='{}' OR service <@ %(service)s)
               AND (event IS NULL OR event=%(event)s)
               AND ("group" IS NULL OR "group"=%(group)s)
               AND (tags='{}' OR tags <@ %(tags)s)
               AND (excluded_tags='{}' OR NOT excluded_tags <@ %(tags)s)
-              AND ARRAY[%(status)s] <@ status
               AND active=true
         """
         if current_app.config['CUSTOMER_VIEWS']:
@@ -1206,10 +1210,8 @@ class Backend(Database):
             update += 'use_oncall=%(useOnCall)s, '
         if kwargs.get('severity') is not None:
             update += 'severity=%(severity)s, '
-        if kwargs.get('advancedSeverity') is not None:
-            update += 'advanced_severity=%(advancedSeverity)s::severity_advanced[], '
-        if kwargs.get('useAdvancedSeverity') is not None:
-            update += 'use_advanced_severity=%(useAdvancedSeverity)s, '
+        if kwargs.get('triggers') is not None:
+            update += 'triggers=%(triggers)s::notification_triggers[], '
         if 'text' in kwargs:
             update += 'text=%(text)s, '
         if 'channelId' in kwargs:
@@ -1361,9 +1363,9 @@ class Backend(Database):
     def create_escalation_rule(self, escalation_rule):
         insert = """
             INSERT INTO escalation_rules (id, active, "time", priority, environment, service, resource, event, "group", tags,
-                customer, "user", create_time, start_time, end_time, days, severity, advanced_severity, use_advanced_severity)
+                customer, "user", create_time, start_time, end_time, days, triggers)
             VALUES (%(id)s, %(active)s, %(time)s, %(priority)s, %(environment)s, %(service)s, %(resource)s, %(event)s, %(group)s, %(tags)s,
-                %(customer)s, %(user)s, %(create_time)s, %(start_time)s, %(end_time)s, %(days)s, %(severity)s, %(advanced_severity)s::severity_advanced[], %(use_advanced_severity)s )
+                %(customer)s, %(user)s, %(create_time)s, %(start_time)s, %(end_time)s, %(days)s, %(triggers)s::notification_triggers[] )
             RETURNING *
         """
         test = self._insert(insert, vars(escalation_rule))
@@ -1403,7 +1405,7 @@ class Backend(Database):
     def get_escalation_alerts(self):
         select = """
             SELECT DISTINCT a.id, a.resource, a.event, a.severity, a.environment, a.service, a.text, a.value, a.timeout
-            FROM public.alerts as a, public.escalation_rules as e, generate_subscripts(e.advanced_severity,1) as s
+            FROM public.alerts as a, public.escalation_rules as e, generate_subscripts(e.triggers,1) as s
             WHERE e.active
                 AND a.status = 'open'
                 AND (%(now)s - a.last_receive_time > e.time)
@@ -1413,8 +1415,7 @@ class Backend(Database):
                 AND (e.event IS NULL OR e.event=a.event or e.event = '')
                 AND (e.group IS NULL OR e.group=a.group)
                 AND (e.tags='{}' OR e.tags <@ a.tags)
-                AND (e.use_advanced_severity=TRUE OR e.severity='{}' OR ARRAY[a.severity] <@ e.severity)
-                AND (e.use_advanced_severity=FALSE OR ((e.advanced_severity[s].from_='{}' OR ARRAY[a.previous_severity] <@ e.advanced_severity[s].from_) AND (e.advanced_severity[s].to='{}' OR ARRAY[a.severity] <@ e.advanced_severity[s].to)))
+                AND (((e.triggers[s].from_severity='{}' OR ARRAY[a.previous_severity] <@ e.triggers[s].from_severity) AND (e.triggers[s].to_severity='{}' OR ARRAY[a.severity] <@ e.triggers[s].to_severity)))
         """
         return self._fetchall(select, {'now': datetime.utcnow()}, limit='ALL')
 
@@ -1447,10 +1448,8 @@ class Backend(Database):
             update += 'days=%(days)s, '
         if kwargs.get('severity') is not None:
             update += 'severity=%(severity)s, '
-        if kwargs.get('advancedSeverity') is not None:
-            update += 'advanced_severity=%(advancedSeverity)s::severity_advanced[], '
-        if kwargs.get('useAdvancedSeverity') is not None:
-            update += 'use_advanced_severity=%(useAdvancedSeverity)s, '
+        if kwargs.get('triggers') is not None:
+            update += 'triggers=%(triggers)s::notification_triggers[], '
         if 'active' in kwargs:
             update += 'active=%(active)s,'
         update += """

--- a/alerta/models/notification_rule.py
+++ b/alerta/models/notification_rule.py
@@ -150,7 +150,7 @@ class NotificationRule:
             user_ids=json.get('userIds'),
             group_ids=json.get('groupIds'),
             use_oncall=json.get('useOnCall', False),
-            triggers=[NotificationTriggers(trigger['from_severity'], trigger['to_severity'], trigger['status'], trigger['text']) for trigger in json.get('triggers', [])],
+            triggers=[NotificationTriggers(trigger.get('from_severity', []), trigger.get('to_severity', []), trigger.get('status'), trigger.get('text', '')) for trigger in json.get('triggers', [])],
             service=json.get('service', list()),
             resource=json.get('resource', None),
             event=json.get('event', None),

--- a/alerta/models/notification_rule.py
+++ b/alerta/models/notification_rule.py
@@ -16,9 +16,9 @@ JSON = Dict[str, Any]
 
 class NotificationTriggers:
     def __init__(self, from_severity: 'list[str]', to_severity: 'list[str]', status: 'list[str]' = [], text: str = "") -> None:
-        self.from_severity = from_severity
-        self.to_severity = to_severity
-        self.status = status
+        self.from_severity = from_severity or []
+        self.to_severity = to_severity or []
+        self.status = status or []
         self.text = text
 
     @property

--- a/alerta/models/notification_rule.py
+++ b/alerta/models/notification_rule.py
@@ -15,26 +15,29 @@ JSON = Dict[str, Any]
 
 
 class AdvancedSeverity:
-    def __init__(self, _from: 'list[str]', _to: 'list[str]') -> None:
+    def __init__(self, _from: 'list[str]', _to: 'list[str]', text: str) -> None:
         self.from_ = _from
         self.to = _to
+        self.text = text
 
     @property
     def serialize(self):
         return {
             'from': self.from_,
-            'to': self.to
+            'to': self.to,
+            'text': self.text
         }
 
     def __repr__(self):
-        return 'AdvancedSeverity(from={!r}, to={!r})'.format(
-            self.from_, self.to)
+        return 'AdvancedSeverity(from={!r}, to={!r}, text={!r})'.format(
+            self.from_, self.to, self.text)
 
     @classmethod
     def from_document(cls, doc):
         return AdvancedSeverity(
             _from=doc.get('from', list()),
-            _to=doc.get('to', list())
+            _to=doc.get('to', list()),
+            text=doc.get('text')
         )
 
     @classmethod
@@ -42,6 +45,7 @@ class AdvancedSeverity:
         return AdvancedSeverity(
             _from=rec.from_,
             _to=rec.to,
+            text=rec.text
         )
 
     @classmethod

--- a/alerta/models/notification_rule.py
+++ b/alerta/models/notification_rule.py
@@ -15,7 +15,7 @@ JSON = Dict[str, Any]
 
 
 class NotificationTriggers:
-    def __init__(self, from_severity: 'list[str]', to_severity: 'list[str]', status: 'list[str]' = [], text: str = "") -> None:
+    def __init__(self, from_severity: 'list[str]', to_severity: 'list[str]', status: 'list[str]' = [], text: str = '') -> None:
         self.from_severity = from_severity or []
         self.to_severity = to_severity or []
         self.status = status or []

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -183,7 +183,7 @@ BEGIN
         ALTER TYPE severity_advanced RENAME TO notification_triggers;
         ALTER TYPE notification_triggers RENAME ATTRIBUTE "from_" TO from_severity;
         ALTER TYPE notification_triggers RENAME ATTRIBUTE "to" TO to_severity;
-        ALTER TYPE notification_triggers ADD ATTRIBUTE "status" text[]; 
+        ALTER TYPE notification_triggers ADD ATTRIBUTE "status" text[];
         ALTER TYPE notification_triggers ADD ATTRIBUTE "text" text;
     END IF;
 END$$;

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -253,6 +253,13 @@ END$$;
 
 DO $$
 BEGIN
+    UPDATE notification_rules SET advanced_severity = '{}' WHERE use_advanced_severity = FALSE;
+EXCEPTION
+    WHEN undefined_column THEN RAISE NOTICE 'column use_advanced_severity do no longer exist in notification_rules';
+END$$;
+
+DO $$
+BEGIN
     ALTER TABLE notification_rules RENAME COLUMN advanced_severity to triggers;
 EXCEPTION
     WHEN duplicate_column THEN RAISE NOTICE 'column "triggers" already exists in notification_rules.';
@@ -260,15 +267,7 @@ END$$;
 
 DO $$
 BEGIN
-    UPDATE notification_rules SET triggers = '{}' WHERE use_advanced_severity = FALSE;
-EXCEPTION
-    WHEN undefined_column THEN RAISE NOTICE 'column use_advanced_severity do no longer exist in notification_rules';
-END$$;
-
-DO $$
-BEGIN
-    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}',severity,'{}', null)::notification_triggers) where severity != '{}';
-    ALTER table notification_rules DROP COLUMN severity;
+    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}',severity,'{}', null)::notification_triggers) where severity != '{}' and "status" = '{}';
 EXCEPTION
     WHEN undefined_column THEN RAISE NOTICE 'column "severity" have already been dropped from notification_rules.';
 END$$;
@@ -290,10 +289,24 @@ END$$;
 
 DO $$
 BEGIN
-    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}','{}',status, null)::notification_triggers) where "status" != '{}';
-    ALTER table notification_rules DROP COLUMN "status";
+    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}','{}',status, null)::notification_triggers) where "status" != '{}' and severity = '{}';
 EXCEPTION
     WHEN undefined_column THEN RAISE NOTICE 'column "status" have already been dropped from notification_rules.';
+END$$;
+
+DO $$
+BEGIN
+    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}', severity, status, null)::notification_triggers) where "status" != '{}' and severity != '{}';
+EXCEPTION
+    WHEN undefined_column THEN RAISE NOTICE 'column "status" have already been dropped from notification_rules.';
+END$$;
+
+DO $$
+BEGIN
+    ALTER table notification_rules DROP COLUMN "status";
+    ALTER table notification_rules DROP COLUMN severity;
+EXCEPTION
+    WHEN undefined_column THEN RAISE NOTICE 'column "status" and severity have already been dropped from notification_rules.';
 END$$;
 
 DO $$

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -311,6 +311,14 @@ END$$;
 
 DO $$
 BEGIN
+    ALTER table notification_rules DROP COLUMN advanced_severity;
+    ALTER table notification_rules DROP COLUMN use_advanced_severity;
+EXCEPTION
+    WHEN undefined_column THEN RAISE NOTICE 'column advanced_severity and use_advanced_severity have already been dropped from notification_rules.';
+END$$;
+
+DO $$
+BEGIN
     ALTER TABLE notification_rules ADD COLUMN active boolean;
     UPDATE notification_rules SET active = true;
 EXCEPTION

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -254,8 +254,10 @@ END$$;
 DO $$
 BEGIN
     ALTER TABLE notification_rules RENAME COLUMN advanced_severity to triggers;
+    UPDATE notification_rules SET triggers = '{}' WHERE use_advanced_severity = FALSE;
 EXCEPTION
     WHEN duplicate_column THEN RAISE NOTICE 'column "triggers" already exists in notification_rules.';
+    WHEN undefined_column THEN RAISE NOTICE 'column use_advanced_severity do no longer exist in notification_rules';
 END$$;
 
 DO $$

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -290,20 +290,8 @@ END$$;
 DO $$
 BEGIN
     UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}','{}',status, null)::notification_triggers) where "status" != '{}' and severity = '{}' and not use_advanced_severity;
-END$$;
-
-DO $$
-BEGIN
     UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}', severity, status, null)::notification_triggers) where "status" != '{}' and severity != '{}' and not use_advanced_severity;
-END$$;
-
-DO $$
-BEGIN
     UPDATE notification_rules as re set triggers = n.f from (SELECT "id", array_agg((tr.from_severity, tr.to_severity, b.status, tr.text)::notification_triggers) as f from notification_rules as b, unnest(triggers) as tr GROUP BY id) as n where "status" != '{}' and use_advanced_severity and n.id = re.id;
-END$$;
-
-DO $$
-BEGIN
     ALTER table notification_rules DROP COLUMN "status";
     ALTER table notification_rules DROP COLUMN severity;
 EXCEPTION

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -153,6 +153,9 @@ BEGIN
             "to" text[]
         );
     END IF;
+    ALTER TYPE severity_advanced ADD ATTRIBUTE "text" text;
+EXCEPTION
+    WHEN duplicate_column THEN RAISE NOTICE 'attribute "text" already exists in type severity_advanced.';
 
 END$$;
 

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -267,7 +267,7 @@ END$$;
 
 DO $$
 BEGIN
-    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}',severity,'{}', null)::notification_triggers) where severity != '{}' and "status" = '{}';
+    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}',severity,'{}', null)::notification_triggers) where severity != '{}' and "status" = '{}' AND NOT use_advanced_severity;
 EXCEPTION
     WHEN undefined_column THEN RAISE NOTICE 'column "severity" have already been dropped from notification_rules.';
 END$$;
@@ -289,14 +289,14 @@ END$$;
 
 DO $$
 BEGIN
-    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}','{}',status, null)::notification_triggers) where "status" != '{}' and severity = '{}';
+    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}','{}',status, null)::notification_triggers) where "status" != '{}' and severity = '{}' and not use_advanced_severity;
 EXCEPTION
     WHEN undefined_column THEN RAISE NOTICE 'column "status" have already been dropped from notification_rules.';
 END$$;
 
 DO $$
 BEGIN
-    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}', severity, status, null)::notification_triggers) where "status" != '{}' and severity != '{}';
+    UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}', severity, status, null)::notification_triggers) where "status" != '{}' and severity != '{}' and not use_advanced_severity;
 EXCEPTION
     WHEN undefined_column THEN RAISE NOTICE 'column "status" have already been dropped from notification_rules.';
 END$$;

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -290,15 +290,16 @@ END$$;
 DO $$
 BEGIN
     UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}','{}',status, null)::notification_triggers) where "status" != '{}' and severity = '{}' and not use_advanced_severity;
-EXCEPTION
-    WHEN undefined_column THEN RAISE NOTICE 'column "status" have already been dropped from notification_rules.';
 END$$;
 
 DO $$
 BEGIN
     UPDATE notification_rules set triggers = ARRAY_APPEND(triggers, ('{}', severity, status, null)::notification_triggers) where "status" != '{}' and severity != '{}' and not use_advanced_severity;
-EXCEPTION
-    WHEN undefined_column THEN RAISE NOTICE 'column "status" have already been dropped from notification_rules.';
+END$$;
+
+DO $$
+BEGIN
+    UPDATE notification_rules as re set triggers = n.f from (SELECT "id", array_agg((tr.from_severity, tr.to_severity, b.status, tr.text)::notification_triggers) as f from notification_rules as b, unnest(triggers) as tr GROUP BY id) as n where "status" != '{}' and use_advanced_severity and n.id = re.id;
 END$$;
 
 DO $$

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -254,9 +254,14 @@ END$$;
 DO $$
 BEGIN
     ALTER TABLE notification_rules RENAME COLUMN advanced_severity to triggers;
-    UPDATE notification_rules SET triggers = '{}' WHERE use_advanced_severity = FALSE;
 EXCEPTION
     WHEN duplicate_column THEN RAISE NOTICE 'column "triggers" already exists in notification_rules.';
+END$$;
+
+DO $$
+BEGIN
+    UPDATE notification_rules SET triggers = '{}' WHERE use_advanced_severity = FALSE;
+EXCEPTION
     WHEN undefined_column THEN RAISE NOTICE 'column use_advanced_severity do no longer exist in notification_rules';
 END$$;
 

--- a/tests/test_notification_rule.py
+++ b/tests/test_notification_rule.py
@@ -517,9 +517,9 @@ class NotificationRuleTestCase(unittest.TestCase):
         pop_event_rule = {**base_rule}
         pop_event_rule.pop('event')
 
-        more_severity_rule = {**base_rule, 'severity': ['major', 'minor', 'critical']}
-        wrong_severity_rule = {**base_rule, 'severity': ['minor']}
-        none_severity_rule = {**base_rule, 'severity': []}
+        more_severity_rule = {**base_rule, 'triggers': [{'to_severity':['major', 'minor', 'critical']}]}
+        wrong_severity_rule = {**base_rule, 'triggers': [{'to_severity':['minor']}]}
+        none_severity_rule = {**base_rule, 'triggers': []}
         pop_severity_rule = {**base_rule}
         pop_severity_rule.pop('severity')
 
@@ -861,27 +861,25 @@ class NotificationRuleTestCase(unittest.TestCase):
 
         self.delete_api_obj('/notificationrules/' + notification_rule_id, self.headers)
 
-    def test_advanced_severity(self):
+    def test_triggers(self):
 
         all = {
             'environment': 'Production',
             'channelId': 'SMS_Channel',
             'receivers': [],
-            'useAdvancedSeverity': True,
             'text': 'administartively sms',
         }
         simple = {
             **all,
-            'useAdvancedSeverity': False,
-            'severity': ['critical', 'major']
+            'triggers': [{'to_severity': ['critical', 'major']}]
         }
         to_critical_major_from_all = {
             **all,
-            'advancedSeverity': [{'from': [], 'to': ['major', 'critical']}],
+            'triggers': [{'to_severity': ['major', 'critical']}]
         }
         to_normal_from_critical_major = {
             **all,
-            'advancedSeverity': [{'from': ['major', 'critical'], 'to': ['normal']}],
+            'triggers': [{'from_severity': ['major', 'critical'], 'to_severity': ['normal']}],
         }
         alert_base = {
             'environment': 'Production',


### PR DESCRIPTION
**Description**
Refactor advanced severity to triggers, add status to triggers, and add a text field for all triggers

**Changes**
- Refac: rename type severity_advanced to notification_triggers
- Refac: rename advanced_severity column in notification_rules to triggers
- Refac: rename advanced_severity column in escalation_rules to triggers
- Refac: move severity and status columns of notificaion_rules into triggers
- Feat: add text column to all triggers

