### PR TITLE
fix: remove empty triggers

### DIFF
--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -346,6 +346,7 @@ BEGIN
     UPDATE public.notification_rules SET event=NULL WHERE event='';
     UPDATE public.notification_rules SET "group"=NULL WHERE "group"='';
     UPDATE notification_rules SET excluded_tags='{}' WHERE excluded_tags IS NULL;
+    UPDATE notification_rules set triggers = ARRAY[('{}', '{}', '{}', null)::notification_triggers] WHERE triggers = '{}';
 
 END$$;
 


### PR DESCRIPTION
**Description**
Remove empty triggers when starting up alerta

**Changes**
- set all empty triggers in NR to an array with an empty trigger.
