### PR TITLE
Refac: remove twilio and sendgrid libraries

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = blinker,click,cryptography,flask,flask_compress,flask_cors,itsdangerous,jwt,ldap,lxml,mohawk,pkg_resources,psycopg2,pymongo,pyparsing,python_http_client,pytest,pytz,requests,requests_hawk,requests_mock,saml2,sendgrid,sentry_sdk,setuptools,twilio,strenum,werkzeug,yaml
+known_third_party = blinker,click,cryptography,flask,flask_compress,flask_cors,itsdangerous,jwt,ldap,lxml,mohawk,pkg_resources,psycopg2,pymongo,pyparsing,python_http_client,pytest,pytz,requests,requests_hawk,requests_mock,saml2,sentry_sdk,setuptools,strenum,werkzeug,yaml

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -981,6 +981,8 @@ class Backend(Database):
             update += 'api_sid=%(apiSid)s, '
         if 'customer' in kwargs:
             update += 'customer=%(customer)s, '
+        if 'sender' in kwargs:
+            update += 'sender=%(sender)s, '
         if 'host' in kwargs:
             update += 'host=%(host)s, '
         if 'platformId' in kwargs:

--- a/alerta/plugins/notification_rule.py
+++ b/alerta/plugins/notification_rule.py
@@ -212,11 +212,13 @@ def handle_channel(message: str, channel: NotificationChannel, notification_rule
 
     elif notification_type == 'smtp':
         try:
-            send_smtp_mail(message, channel, notification_rule.receivers, users, fernet)
+            send_smtp_mail(message, channel, {*notification_rule.receivers, *[user.email for user in users]}, users, fernet)
+            log_notification(True, message, channel, notification_rule.id, alert, {*notification_rule.receivers, *[user.email for user in users]})
         except InvalidToken:
             log_notification(False, message, channel, notification_rule.id, alert, {*notification_rule.receivers, *[user.email for user in users]}, 'NotificationChannel: Failed to decrypt authentication keys')
             LOG.error('NotificationChannel: Failed to decrypt authentication keys. Hint: check that NOTIFICATION_KEY environment variable is set and unchanged since the channel was made')
         except Exception as err:
+            log_notification(False, message, channel, notification_rule.id, alert, {*notification_rule.receivers, *[user.email for user in users]}, str(err))
             LOG.error('NotificationRule: %s', str(err))
 
     elif 'twilio' in notification_type:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,4 @@ sendgrid==6.5.0
 sentry-sdk[flask]==1.45.0
 starkbank-ecdsa==1.0.0
 StrEnum==0.4.15
-twilio==7.0.0
 werkzeug==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ pytz==2024.1
 PyYAML==6.0.1
 requests==2.31.0
 requests_hawk==1.2.1
-sendgrid==6.5.0
 sentry-sdk[flask]==1.45.0
 starkbank-ecdsa==1.0.0
 StrEnum==0.4.15

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
   python-ldap
   lxml
   pysaml2
-  sendgrid
 
 whitelist_externals =
   createdb

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
   python-ldap
   lxml
   pysaml2
-  twilio
   sendgrid
 
 whitelist_externals =


### PR DESCRIPTION
**Description**
Remove Twilio and Sendgrid libraries, and use simple post requests to send SMS. 

**Changes**
- refac: remove twilio and sendgrid libraries
- fix:  change error handling of invalid NotificationKey to log that decryption of notification authentication failed
- fix: add update of sender in notification channels


