### PR TITLE
fix: add or functions betweeen groups of or/and functions in excluded tags

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1161,8 +1161,8 @@ class Backend(Database):
                     AND (tags[t].any='{}' OR tags[t].any && %(tags)s)
             ), alert_excluded AS (
                 SELECT * FROM (select *, generate_subscripts(excluded_tags,1) as ex FROM alert_tags) as foo
-                WHERE (excluded_tags[ex].all='{}' OR NOT excluded_tags[ex].all <@ %(tags)s)
-                    AND (excluded_tags[ex].any='{}' OR NOT excluded_tags[ex].any && %(tags)s)
+                WHERE NOT ((excluded_tags[ex].all='{}' OR excluded_tags[ex].all <@ %(tags)s)
+                    AND (excluded_tags[ex].any='{}' OR excluded_tags[ex].any && %(tags)s))
             )
 
             SELECT * from notification_rules
@@ -1206,8 +1206,8 @@ class Backend(Database):
                     AND (tags[t].any='{}' OR tags[t].any && %(tags)s)
             ), alert_excluded AS (
                 SELECT * FROM (select *, generate_subscripts(excluded_tags,1) as ex FROM alert_tags) as foo
-                WHERE (excluded_tags[ex].all='{}' OR NOT excluded_tags[ex].all <@ %(tags)s)
-                    AND (excluded_tags[ex].any='{}' OR NOT excluded_tags[ex].any && %(tags)s)
+                WHERE NOT ((excluded_tags[ex].all='{}' OR excluded_tags[ex].all <@ %(tags)s)
+                    AND (excluded_tags[ex].any='{}' OR excluded_tags[ex].any && %(tags)s))
             )
 
             SELECT * from notification_rules

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -190,7 +190,7 @@ class Backend(Database):
     def destroy(self):
         conn = self.connect()
         cursor = conn.cursor()
-        for table in ['alerts', 'blackouts', 'notification_rules', 'notification_history', 'notification_channels', 'on_calls', 'customers', 'groups', 'heartbeats', 'keys', 'metrics', 'perms', 'users', 'delayed_notifications']:
+        for table in ['alerts', 'blackouts', 'escalation_rules', 'notification_rules', 'notification_history', 'notification_channels', 'on_calls', 'customers', 'groups', 'heartbeats', 'keys', 'metrics', 'perms', 'users', 'delayed_notifications']:
             cursor.execute(f'DROP TABLE IF EXISTS {table}')
         conn.commit()
         conn.close()
@@ -1467,6 +1467,7 @@ class Backend(Database):
                 FROM public.alerts as a, public.escalation_rules as e, generate_subscripts(e.triggers,1) as s
                 WHERE e.active
                     AND a.status = 'open'
+                    AND (%(now)s - a.last_receive_time > e.time)
                     AND a.environment=e.environment
                     AND (e.resource IS NULL OR e.resource=a.resource OR e.resource = '')
                     AND (e.service='{}' OR e.service <@ a.service)

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1160,14 +1160,17 @@ class Backend(Database):
                 WHERE (tags[t].all='{}' OR tags[t].all <@ %(tags)s)
                     AND (tags[t].any='{}' OR tags[t].any && %(tags)s)
             ), alert_excluded AS (
-                SELECT * FROM (select *, generate_subscripts(excluded_tags,1) as ex FROM alert_tags) as foo
-                WHERE NOT ((excluded_tags[ex].all='{}' OR excluded_tags[ex].all <@ %(tags)s)
-                    AND (excluded_tags[ex].any='{}' OR excluded_tags[ex].any && %(tags)s))
+                SELECT id FROM (select * FROM alert_tags, unnest(excluded_tags) as t("e_all","e_any")) as foo
+                WHERE NOT ("e_all"='{}' AND "e_any"='{}')
+                AND (
+                    ("e_all"='{}' AND %(tags)s && "e_any")
+                    OR ("e_any"='{}' AND %(tags)s @> "e_all")
+                    OR (%(tags)s @> "e_all" AND %(tags)s && "e_any")
+                )
             )
 
-            SELECT * from notification_rules
-            WHERE id IN (SELECT id FROM alert_excluded)
-
+            SELECT * from alert_tags
+            WHERE alert_tags.id NOT IN (SELECT DISTINCT alert_excluded.id FROM alert_excluded)
         """
         if current_app.config['CUSTOMER_VIEWS']:
             select += ' AND (customer IS NULL OR customer=%(customer)s)'
@@ -1205,13 +1208,17 @@ class Backend(Database):
                 WHERE (tags[t].all='{}' OR tags[t].all <@ %(tags)s)
                     AND (tags[t].any='{}' OR tags[t].any && %(tags)s)
             ), alert_excluded AS (
-                SELECT * FROM (select *, generate_subscripts(excluded_tags,1) as ex FROM alert_tags) as foo
-                WHERE NOT ((excluded_tags[ex].all='{}' OR excluded_tags[ex].all <@ %(tags)s)
-                    AND (excluded_tags[ex].any='{}' OR excluded_tags[ex].any && %(tags)s))
+                SELECT id FROM (select * FROM alert_tags, unnest(excluded_tags) as t("e_all","e_any")) as foo
+                WHERE NOT ("e_all"='{}' AND "e_any"='{}')
+                AND (
+                    ("e_all"='{}' AND %(tags)s && "e_any")
+                    OR ("e_any"='{}' AND %(tags)s @> "e_all")
+                    OR (%(tags)s @> "e_all" AND %(tags)s && "e_any")
+                )
             )
 
-            SELECT * from notification_rules
-            WHERE id IN (SELECT id FROM alert_excluded)
+            SELECT * from alert_tags
+            WHERE alert_tags.id NOT IN (SELECT DISTINCT alert_excluded.id FROM alert_excluded)
         """
         if current_app.config['CUSTOMER_VIEWS']:
             select += ' AND (customer IS NULL OR customer=%(customer)s)'
@@ -1471,13 +1478,18 @@ class Backend(Database):
                 SELECT DISTINCT a.* from alert_triggers as a, public.escalation_rules as e, generate_subscripts(e.tags,1) as t
                 WHERE (e.tags[t].all='{}' OR e.tags[t].all <@ a.tags)
                     AND (e.tags[t].any='{}' OR e.tags[t].any && a.tags)
+            ), alert_excluded AS (
+                SELECT a.id FROM alert_tags as a, public.escalation_rules as e, unnest(e.excluded_tags) as t("e_all","e_any")
+                WHERE NOT ("e_all"='{}' AND "e_any"='{}')
+                AND (
+                    ("e_all"='{}' AND a.tags && "e_any")
+                    OR ("e_any"='{}' AND a.tags @> "e_all")
+                    OR (a.tags @> "e_all" AND a.tags && "e_any")
+                )
             )
 
-            SELECT DISTINCT a.id, a.resource, a.event, a.severity, a.environment, a.service, a.text, a.value, a.timeout
-            from alert_tags as a, public.escalation_rules as e, generate_subscripts(e.excluded_tags,1) as t
-            WHERE NOT ((e.excluded_tags[t].all='{}' OR e.excluded_tags[t].all <@ a.tags)
-                AND (e.excluded_tags[t].any='{}' OR (e.excluded_tags[t].any && a.tags)))
-
+            SELECT * from alert_tags
+            WHERE alert_tags.id NOT IN (SELECT DISTINCT alert_excluded.id FROM alert_excluded)
         """
         return self._fetchall(select, {'now': datetime.utcnow()}, limit='ALL')
 

--- a/alerta/views/notification_rules.py
+++ b/alerta/views/notification_rules.py
@@ -91,6 +91,24 @@ def get_notification_rules_active():
     return jsonify(status='ok', total=total, notificationRules=notification_rules)
 
 
+@api.route('/notificationrules/activestatus', methods=['OPTIONS', 'POST'])
+@cross_origin()
+@permission(Scope.read_on_calls)
+@jsonp
+def get_notification_rules_activestatus():
+    alert_json = request.json
+    if alert_json is None or alert_json.get('id') is None:
+        return jsonify(status='ok', total=0, notificationRules=[])
+    try:
+        alert = Alert.find_by_id(alert_json.get('id'))
+    except Exception as e:
+        raise ApiError(str(e), 400)
+
+    notification_rules = [notification_rule.serialize for notification_rule in NotificationRule.find_all_active_status(alert, alert.status)]
+    total = len(notification_rules)
+    return jsonify(status='ok', total=total, notificationRules=notification_rules)
+
+
 @api.route('/notificationrules', methods=['OPTIONS', 'GET'])
 @cross_origin()
 @permission(Scope.read_notification_rules)

--- a/tests/test_escalation_rule.py
+++ b/tests/test_escalation_rule.py
@@ -1,0 +1,302 @@
+import json
+import logging
+import unittest
+from datetime import datetime, timedelta
+
+from alerta.app import create_app, db, plugins
+from alerta.models.key import ApiKey
+
+LOG = logging.getLogger('test.test_notification_rule')
+
+
+def get_id(object: dict):
+    return object['id']
+
+
+class EscalationRuleTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        test_config = {
+            'TESTING': True,
+            'AUTH_REQUIRED': True,
+            'CUSTOMER_VIEWS': True,
+            'PLUGINS': [],
+        }
+        self.app = create_app(test_config)
+        self.client = self.app.test_client()
+
+        self.prod_alert = {
+            'resource': 'node404',
+            'event': 'node_down',
+            'environment': 'Production',
+            'severity': 'minor',
+            'correlate': ['node_down', 'node_marginal', 'node_up'],
+            'service': ['Core', 'Web', 'Network'],
+            'group': 'Network',
+            'tags': ['level=20', 'switch:off'],
+        }
+
+        with self.app.test_request_context('/'):
+            self.app.preprocess_request()
+            self.admin_api_key = ApiKey(
+                user='admin@alerta.io',
+                scopes=['admin', 'read', 'write'],
+                text='demo-key',
+            )
+            self.customer_api_key = ApiKey(
+                user='admin@alerta.io',
+                scopes=['admin', 'read', 'write'],
+                text='demo-key',
+                customer='Foo',
+            )
+            self.admin_api_key.create()
+            self.customer_api_key.create()
+
+        self.headers = {
+            'Authorization': f'Key {self.admin_api_key.key}',
+            'Content-type': 'application/json',
+        }
+
+    def tearDown(self) -> None:
+        plugins.plugins.clear()
+        db.destroy()
+
+    def create_api_obj(self, apiurl: str, apidata: dict, apiheaders: dict, status_code: int = 201) -> dict:
+        response = self.client.post(apiurl, data=json.dumps(apidata), headers=apiheaders)
+        self.assertEqual(response.status_code, status_code)
+        return json.loads(response.data.decode('utf-8'))
+
+    def update_api_obj(self, apiurl: str, apidata: dict, apiheaders: dict, status_code: int = 200) -> dict:
+        response = self.client.put(apiurl, data=json.dumps(apidata), headers=apiheaders)
+        self.assertEqual(response.status_code, status_code)
+        return json.loads(response.data.decode('utf-8'))
+
+    def get_api_obj(self, apiurl: str, apiheaders: dict, status_code: int = 200) -> dict:
+        response = self.client.get(apiurl, headers=apiheaders)
+        self.assertEqual(response.status_code, status_code)
+        return json.loads(response.data.decode('utf-8'))
+
+    def delete_api_obj(self, apiurl: str, apiheaders: dict, status_code: int = 200) -> dict:
+        response = self.client.delete(apiurl, headers=apiheaders)
+        self.assertEqual(response.status_code, status_code)
+        return json.loads(response.data.decode('utf-8'))
+
+    def test_escalation_rule(self):
+
+        escalation_rule = {
+            'environment': 'Production',
+            'tags': [],
+            'time': '1 second'
+        }
+
+        self.create_api_obj('/escalationrules', escalation_rule, self.headers)
+
+        start = datetime.now()
+        alert = self.create_api_obj('/alert', self.prod_alert, self.headers)['alert']
+        escalated_alerts = self.get_api_obj('/escalate', self.headers, 200)['alerts']
+        self.assertNotIn(alert['id'], map(get_id, escalated_alerts))
+
+        while len(escalated_alerts) == 0:
+            escalated_alerts = self.get_api_obj('/escalate', self.headers, 200)['alerts']
+        self.assertTrue(datetime.now() - start >= timedelta(seconds=1))
+        self.assertIn(alert['id'], map(get_id, escalated_alerts))
+        new_data = self.get_api_obj(f"/alert/{alert['id']}", self.headers)['alert']
+        self.assertEqual(alert['severity'], "minor")
+        self.assertEqual(new_data['severity'], "major")
+
+    def test_detail(self):
+
+        escalation_rule = {
+            'environment': 'Production',
+            'resource': 'node404',
+            'group': 'Network',
+            'service': ['Core', 'Web', 'Network'],
+            'tags': [],
+            'time': '0 second'
+        }
+
+        self.prod_alert['event'] = 'normal'
+        wrong_service = {**self.prod_alert, 'service': ['Test'], 'event': 'wrong_service'}
+        wrong_resource = {**self.prod_alert, 'resource': 'test', 'event': 'wrong_resource'}
+        wrong_environment = {**self.prod_alert, 'environment': 'Development', 'event': 'wrong_environment'}
+        wrong_group = {**self.prod_alert, 'group': 'test', 'event': 'wrong_group'}
+
+        self.create_api_obj('/escalationrules', escalation_rule, self.headers)
+
+        alert = self.create_api_obj('/alert', self.prod_alert, self.headers)['alert']
+        wrong_service_alert = self.create_api_obj('/alert', wrong_service, self.headers)['alert']
+        wrong_resource_alert = self.create_api_obj('/alert', wrong_resource, self.headers)['alert']
+        wrong_environment_alert = self.create_api_obj('/alert', wrong_environment, self.headers)['alert']
+        wrong_group_alert = self.create_api_obj('/alert', wrong_group, self.headers)['alert']
+        escalated_alerts = self.get_api_obj('/escalate', self.headers, 200)['alerts']
+        self.assertIn(alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(wrong_service_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(wrong_resource_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(wrong_environment_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(wrong_group_alert['id'], map(get_id, escalated_alerts))
+        new_data = self.get_api_obj(f"/alert/{alert['id']}", self.headers)['alert']
+        self.assertEqual(alert['severity'], "minor")
+        self.assertEqual(new_data['severity'], "major")
+
+    def test_event(self):
+
+        escalation_rule = {
+            'environment': 'Production',
+            'event': 'event',
+            'service': ['Core', 'Web', 'Network'],
+            'tags': [],
+            'time': '0 second'
+        }
+
+        self.prod_alert['event'] = 'event'
+        wrong_event = {**self.prod_alert, 'service': ['Test'], 'event': 'wrong_service'}
+
+        self.create_api_obj('/escalationrules', escalation_rule, self.headers)
+
+        alert = self.create_api_obj('/alert', self.prod_alert, self.headers)['alert']
+        wrong_event_alert = self.create_api_obj('/alert', wrong_event, self.headers)['alert']
+        escalated_alerts = self.get_api_obj('/escalate', self.headers, 200)['alerts']
+        self.assertIn(alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(wrong_event_alert['id'], map(get_id, escalated_alerts))
+        new_data = self.get_api_obj(f"/alert/{alert['id']}", self.headers)['alert']
+        self.assertEqual(alert['severity'], "minor")
+        self.assertEqual(new_data['severity'], "major")
+
+    def test_tags(self):
+
+        escalation_rule = {
+            'environment': 'Production',
+            'tags': [{'all':['test', 'dev'], 'any':['all', 'any']}],
+            'time': '0 second'
+        }
+        missing_tags = {
+            'resource': 'missing_tags',
+            'event': 'missing_tags',
+            'environment': 'Production',
+            'severity': 'minor',
+            'service': ['Tags'],
+            'group': 'Tags',
+            'tags': [],
+        }
+        or_tags = {**missing_tags,'tags': ['any', 'all'], 'resource': 'or_tags'}
+        and_tags = {**missing_tags,'tags': ['test', 'dev'], 'resource': 'and_tags'}
+        partial_or_tags = {**missing_tags,'tags': ['test', 'dev', 'any'], 'resource': 'partial_or_tags'}
+        all_tags = {**missing_tags,'tags': ['test', 'dev', 'any', 'all'], 'resource': 'all_tags'}
+
+        self.create_api_obj('/escalationrules', escalation_rule, self.headers)
+
+        alert = self.create_api_obj('/alert', missing_tags, self.headers)['alert']
+        or_tags_alert = self.create_api_obj('/alert', or_tags, self.headers)['alert']
+        and_tags_alert = self.create_api_obj('/alert', and_tags, self.headers)['alert']
+        partial_or_tags_alert = self.create_api_obj('/alert', partial_or_tags, self.headers)['alert']
+        all_tags_alert = self.create_api_obj('/alert', all_tags, self.headers)['alert']
+        escalated_alerts = self.get_api_obj('/escalate', self.headers, 200)['alerts']
+        self.assertNotIn(alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(or_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(and_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertIn(partial_or_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertIn(all_tags_alert['id'], map(get_id, escalated_alerts))
+
+    def test_full_excluded_tags(self):
+        escalation_rule = {
+            'environment': 'Production',
+            'tags': [],
+            'excludedTags': [{'all':['test', 'dev'], 'any':['all', 'any']}],
+            'time': '0 second'
+        }
+        missing_tags = {
+            'resource': 'missing_tags',
+            'event': 'missing_tags',
+            'environment': 'Production',
+            'severity': 'minor',
+            'service': ['Tags'],
+            'group': 'Tags',
+            'tags': [],
+        }
+        or_tags = {**missing_tags,'tags': ['any', 'all'], 'resource': 'or_tags'}
+        and_tags = {**missing_tags,'tags': ['test', 'dev'], 'resource': 'and_tags'}
+        partial_or_tags = {**missing_tags,'tags': ['test', 'dev', 'any'], 'resource': 'partial_or_tags'}
+        all_tags = {**missing_tags,'tags': ['test', 'dev', 'any', 'all'], 'resource': 'all_tags'}
+
+        self.create_api_obj('/escalationrules', escalation_rule, self.headers)
+
+        alert = self.create_api_obj('/alert', missing_tags, self.headers)['alert']
+        or_tags_alert = self.create_api_obj('/alert', or_tags, self.headers)['alert']
+        and_tags_alert = self.create_api_obj('/alert', and_tags, self.headers)['alert']
+        partial_or_tags_alert = self.create_api_obj('/alert', partial_or_tags, self.headers)['alert']
+        all_tags_alert = self.create_api_obj('/alert', all_tags, self.headers)['alert']
+        escalated_alerts = self.get_api_obj('/escalate', self.headers, 200)['alerts']
+        self.assertIn(alert['id'], map(get_id, escalated_alerts))
+        self.assertIn(or_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertIn(and_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(partial_or_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(all_tags_alert['id'], map(get_id, escalated_alerts))
+
+    def test_or_excluded_tags(self):
+        escalation_rule = {
+            'environment': 'Production',
+            'tags': [],
+            'excludedTags': [{'any':['all', 'any']}],
+            'time': '0 second'
+        }
+        missing_tags = {
+            'resource': 'missing_tags',
+            'event': 'missing_tags',
+            'environment': 'Production',
+            'severity': 'minor',
+            'service': ['Tags'],
+            'group': 'Tags',
+            'tags': [],
+        }
+        or_tags = {**missing_tags,'tags': ['any', 'all'], 'resource': 'or_tags'}
+        and_tags = {**missing_tags,'tags': ['test', 'dev'], 'resource': 'and_tags'}
+        partial_or_tags = {**missing_tags,'tags': ['test', 'dev', 'any'], 'resource': 'partial_or_tags'}
+        all_tags = {**missing_tags,'tags': ['test', 'dev', 'any', 'all'], 'resource': 'all_tags'}
+
+        self.create_api_obj('/escalationrules', escalation_rule, self.headers)
+
+        alert = self.create_api_obj('/alert', missing_tags, self.headers)['alert']
+        or_tags_alert = self.create_api_obj('/alert', or_tags, self.headers)['alert']
+        and_tags_alert = self.create_api_obj('/alert', and_tags, self.headers)['alert']
+        partial_or_tags_alert = self.create_api_obj('/alert', partial_or_tags, self.headers)['alert']
+        all_tags_alert = self.create_api_obj('/alert', all_tags, self.headers)['alert']
+        escalated_alerts = self.get_api_obj('/escalate', self.headers, 200)['alerts']
+        self.assertIn(alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(or_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertIn(and_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(partial_or_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(all_tags_alert['id'], map(get_id, escalated_alerts))
+
+    def test_all_excluded_tags(self):
+        escalation_rule = {
+            'environment': 'Production',
+            'tags': [],
+            'excludedTags': [{'all':['test', 'dev']}],
+            'time': '0 second'
+        }
+        missing_tags = {
+            'resource': 'missing_tags',
+            'event': 'missing_tags',
+            'environment': 'Production',
+            'severity': 'minor',
+            'service': ['Tags'],
+            'group': 'Tags',
+            'tags': [],
+        }
+        or_tags = {**missing_tags,'tags': ['any', 'all'], 'resource': 'or_tags'}
+        and_tags = {**missing_tags,'tags': ['test', 'dev'], 'resource': 'and_tags'}
+        partial_or_tags = {**missing_tags,'tags': ['test', 'dev', 'any'], 'resource': 'partial_or_tags'}
+        all_tags = {**missing_tags,'tags': ['test', 'dev', 'any', 'all'], 'resource': 'all_tags'}
+
+        self.create_api_obj('/escalationrules', escalation_rule, self.headers)
+
+        alert = self.create_api_obj('/alert', missing_tags, self.headers)['alert']
+        or_tags_alert = self.create_api_obj('/alert', or_tags, self.headers)['alert']
+        and_tags_alert = self.create_api_obj('/alert', and_tags, self.headers)['alert']
+        partial_or_tags_alert = self.create_api_obj('/alert', partial_or_tags, self.headers)['alert']
+        all_tags_alert = self.create_api_obj('/alert', all_tags, self.headers)['alert']
+        escalated_alerts = self.get_api_obj('/escalate', self.headers, 200)['alerts']
+        self.assertIn(alert['id'], map(get_id, escalated_alerts))
+        self.assertIn(or_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(and_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(partial_or_tags_alert['id'], map(get_id, escalated_alerts))
+        self.assertNotIn(all_tags_alert['id'], map(get_id, escalated_alerts))

--- a/tests/test_escalation_rule.py
+++ b/tests/test_escalation_rule.py
@@ -100,8 +100,8 @@ class EscalationRuleTestCase(unittest.TestCase):
         self.assertTrue(datetime.now() - start >= timedelta(seconds=1))
         self.assertIn(alert['id'], map(get_id, escalated_alerts))
         new_data = self.get_api_obj(f"/alert/{alert['id']}", self.headers)['alert']
-        self.assertEqual(alert['severity'], "minor")
-        self.assertEqual(new_data['severity'], "major")
+        self.assertEqual(alert['severity'], 'minor')
+        self.assertEqual(new_data['severity'], 'major')
 
     def test_detail(self):
 
@@ -134,8 +134,8 @@ class EscalationRuleTestCase(unittest.TestCase):
         self.assertNotIn(wrong_environment_alert['id'], map(get_id, escalated_alerts))
         self.assertNotIn(wrong_group_alert['id'], map(get_id, escalated_alerts))
         new_data = self.get_api_obj(f"/alert/{alert['id']}", self.headers)['alert']
-        self.assertEqual(alert['severity'], "minor")
-        self.assertEqual(new_data['severity'], "major")
+        self.assertEqual(alert['severity'], 'minor')
+        self.assertEqual(new_data['severity'], 'major')
 
     def test_event(self):
 
@@ -158,8 +158,8 @@ class EscalationRuleTestCase(unittest.TestCase):
         self.assertIn(alert['id'], map(get_id, escalated_alerts))
         self.assertNotIn(wrong_event_alert['id'], map(get_id, escalated_alerts))
         new_data = self.get_api_obj(f"/alert/{alert['id']}", self.headers)['alert']
-        self.assertEqual(alert['severity'], "minor")
-        self.assertEqual(new_data['severity'], "major")
+        self.assertEqual(alert['severity'], 'minor')
+        self.assertEqual(new_data['severity'], 'major')
 
     def test_tags(self):
 


### PR DESCRIPTION
**Description**
Change db checks of excluded tags to only need to have one and/or function match tags in incoming alert to stop notification/escalation.

**Changes**
- fix db query for excluded tags in notification rules
- fix db query for excluded tags in escalation rules