### PR TITLE
fix: add status check for plugins and alerta model

### DIFF
--- a/alerta/models/alarms/alerta_isa_18_2.py
+++ b/alerta/models/alarms/alerta_isa_18_2.py
@@ -124,6 +124,8 @@ class StateMachine(AlarmModel):
             return severity, status
 
         if not action and alert.status != StateMachine.DEFAULT_STATUS:
+            statuses = StateMachine.Status.keys()
+            assert alert.status in statuses, f"Status is not one of {', '.join(statuses)}"
             return next_state('External State Change, Any (*) -> Any (*)', current_severity, alert.status)
 
         if action == ACTION_SHELVE:

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -37,6 +37,9 @@ class Alert:
         for attr in ['create_time', 'receive_time', 'last_receive_time']:
             if not isinstance(kwargs.get(attr), (datetime, NoneType)):  # type: ignore
                 raise ValueError(f"Attribute '{attr}' must be datetime type")
+        if kwargs.get('status') is not None:
+            if kwargs['status'] not in alarm_model.Status.keys():
+                raise ValueError(f'Status must be one of: {", ".join(alarm_model.Status.keys())}')
 
         timeout = kwargs.get('timeout') if kwargs.get('timeout') is not None else current_app.config['ALERT_TIMEOUT']
         try:


### PR DESCRIPTION
**Description**
Add a check that a new status correspond with a status in the Alarm model

**Changes**
- Add check in ALERTA_ISA_18_2 model that checks the status assigned after running plugins
-Add check in Alerta model that checks the status of incoming request/data