### PR TITLE
feat: add notification send for sending custom sms and mail to users and notification groups

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -2,6 +2,7 @@ import threading
 import time
 from collections import defaultdict, namedtuple
 from datetime import datetime, timedelta
+from uuid import uuid4
 
 import psycopg2
 from flask import current_app
@@ -1368,6 +1369,52 @@ class Backend(Database):
             RETURNING id
         """
         return self._deleteone(delete, (id,), returning=True)
+
+# NOTIFICATION SEND
+    def get_notification_sends(self):
+        select_users = """
+            SELECT name, email FROM users
+            WHERE email NOT IN (select user_email from notification_sends where user_email is not null)
+        """
+        users = self._fetchall(select_users, [])
+        if len(users):
+            insert_users = 'INSERT INTO notification_sends (id, user_name, user_email, mail, sms) VALUES'
+            users_data = {}
+            for user in users:
+                index = users.index(user)
+                insert_users += f'(%(email_{index})s, %(name_{index})s, %(email_{index})s, false, false),'
+                users_data = {**users_data, **{f'email_{index}': user.email, f'name_{index}': user.name, f'id_{index}': str(uuid4())}}
+            insert_users = insert_users[:-1]
+            self._insert(insert_users, users_data)
+
+        insert_groups = """
+            INSERT INTO notification_sends (id, group_name, mail, sms)
+            SELECT id, name, false, false from notification_groups
+            ON CONFLICT DO NOTHING
+        """
+        try:
+            self._insert(insert_groups, [])
+        except psycopg2.ProgrammingError:
+            pass
+        select = 'SELECT * FROM notification_sends'
+        return self._fetchall(select, [])
+
+    def update_notification_send(self, id, **kwargs):
+        update = """
+            UPDATE notification_sends
+            SET
+        """
+        if 'mail' in kwargs:
+            update += 'mail=%(mail)s, '
+        if 'sms' in kwargs:
+            update += 'sms=%(sms)s, '
+        update = update[0:-2]
+        update += """
+            WHERE id=%(id)s
+            RETURNING *
+        """
+        kwargs['id'] = id
+        return self._updateone(update, kwargs, returning=True)
 
 # NOTIFICATION SENT
 

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -191,7 +191,7 @@ class Backend(Database):
     def destroy(self):
         conn = self.connect()
         cursor = conn.cursor()
-        for table in ['alerts', 'blackouts', 'escalation_rules', 'notification_rules', 'notification_history', 'notification_channels', 'on_calls', 'customers', 'groups', 'heartbeats', 'keys', 'metrics', 'perms', 'users', 'delayed_notifications']:
+        for table in ['alerts', 'blackouts', 'escalation_rules', 'notification_rules', 'notification_history', 'notification_channels', 'on_calls', 'customers', 'groups', 'heartbeats', 'keys', 'metrics', 'perms', 'notification_sends', 'users', 'delayed_notifications']:
             cursor.execute(f'DROP TABLE IF EXISTS {table}')
         conn.commit()
         conn.close()

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -346,6 +346,13 @@ class Database(Base):
     def delete_notification_group(self, id):
         raise NotImplementedError
 
+    # NOTIFICATION SEND
+    def get_notification_sends(self):
+        raise NotImplementedError
+
+    def update_notification_send(self, id, **kwargs):
+        raise NotImplementedError
+
     # NOTIFICATION HISTORY
 
     def create_notification_history(self, notification_history):

--- a/alerta/models/enums.py
+++ b/alerta/models/enums.py
@@ -76,6 +76,7 @@ class Scope(str):
     read_notification_groups = 'read:notification_groups'
     write_notification_groups = 'write:notification_groups'
     admin_notification_groups = 'admin:notification_groups'
+    write_notification_sends = 'write:notification_sends'
     read_escalation_rules = 'read:escalation_rules'
     write_escalation_rules = 'write:escalation_rules'
     admin_escalation_rules = 'admin:escalation_rules'

--- a/alerta/models/notification_send.py
+++ b/alerta/models/notification_send.py
@@ -1,0 +1,67 @@
+from typing import Any, Dict, List, Tuple, Union
+
+from alerta.app import db
+
+JSON = Dict[str, Any]
+
+
+class NotificationSend:
+    def __init__(self, **kwargs) -> None:
+        self.id = kwargs.get('id')
+        self.name = kwargs.get('user_name') or kwargs.get('group_name')
+        self.type = 'User' if kwargs.get('user_name') else 'Group'
+        self.mail = kwargs.get('mail')
+        self.sms = kwargs.get('sms')
+
+    @property
+    def serialize(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'name': self.name,
+            'mail': self.mail,
+            'sms': self.sms,
+            'type': self.type
+        }
+
+    def __repr__(self) -> str:
+        return 'NotificationSend(id={!r}, name={!r}, email={!r}, sms={!r})'.format(
+            self.id,
+            self.name,
+            self.mail,
+            self.sms,
+        )
+
+    @classmethod
+    def from_document(cls, doc: Dict[str, Any]) -> 'NotificationSend':
+        return NotificationSend(
+            id=doc.get('id', None) or doc.get('_id'),
+            user_name=doc.get('user_name'),
+            group_name=doc.get('group_name'),
+            mail=doc.get('mail'),
+            sms=doc.get('sms'),
+        )
+
+    @classmethod
+    def from_record(cls, rec) -> 'NotificationSend':
+        return NotificationSend(
+            id=rec.id,
+            user_name=rec.user_name,
+            group_name=rec.group_name,
+            mail=rec.mail,
+            sms=rec.sms,
+        )
+
+    @classmethod
+    def from_db(cls, r: Union[Dict, Tuple]) -> 'NotificationSend':
+        if isinstance(r, dict):
+            return cls.from_document(r)
+        elif isinstance(r, tuple):
+            return cls.from_record(r)
+
+    @staticmethod
+    def find_all() -> List['NotificationSend']:
+        return [NotificationSend.from_db(send) for send in db.get_notification_sends()]
+
+    @staticmethod
+    def update(id, **kwargs) -> 'NotificationSend':
+        return NotificationSend.from_db(db.update_notification_send(id, **kwargs))

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -559,6 +559,15 @@ EXCEPTION
     WHEN duplicate_column THEN RAISE NOTICE 'column "phone_number" already exists in users.';
 END$$;
 
+CREATE TABLE IF NOT EXISTS notification_sends(
+    id TEXT PRIMARY KEY,
+    user_name TEXT,
+    user_email TEXT REFERENCES users(email) ON DELETE CASCADE,
+    group_name text REFERENCES notification_groups(name) ON DELETE CASCADE,
+    mail BOOLEAN,
+    sms BOOLEAN
+);
+
 CREATE TABLE IF NOT EXISTS groups (
     id text PRIMARY KEY,
     name text UNIQUE NOT NULL,

--- a/alerta/views/__init__.py
+++ b/alerta/views/__init__.py
@@ -6,7 +6,7 @@ from alerta.utils.response import absolute_url
 
 api = Blueprint('api', __name__)
 
-from . import alerts, blackouts, config, customers, groups, heartbeats, keys, oembed, permissions, users, notification_rules, notification_channels, notification_history, on_call, escalation_rules, notification_groups, notification_delays  # noqa isort:skip
+from . import alerts, blackouts, config, customers, groups, heartbeats, keys, oembed, permissions, users, notification_rules, notification_channels, notification_history, on_call, escalation_rules, notification_groups, notification_delays, notification_sends  # noqa isort:skip
 
 try:
     from . import bulk  # noqa

--- a/alerta/views/notification_sends.py
+++ b/alerta/views/notification_sends.py
@@ -1,0 +1,75 @@
+from flask import jsonify, request
+from flask_cors import cross_origin
+
+from alerta.app import plugins
+from alerta.auth.decorators import permission
+from alerta.exceptions import ApiError
+from alerta.models.enums import Scope
+from alerta.models.notification_channel import NotificationChannel
+from alerta.models.notification_rule import NotificationRule
+from alerta.models.notification_send import NotificationSend
+from alerta.models.user import User
+from alerta.plugins.notification_rule import handle_test
+from alerta.utils.response import jsonp
+
+from . import api
+
+
+@api.route('/notificationsends', methods=['OPTIONS', 'GET'])
+@cross_origin()
+@permission(Scope.read_notification_groups)
+@permission(Scope.admin_users)
+@permission(Scope.write_notification_sends)
+@jsonp
+def list_notification_sends():
+    notification_sends = NotificationSend.find_all()
+
+    if notification_sends:
+        return jsonify(
+            status='ok',
+            notificationSends=[send.serialize for send in notification_sends],
+            total=len(notification_sends),
+        )
+    else:
+        return jsonify(
+            status='ok',
+            message='not found',
+            notificationSends=[],
+            total=0,
+        )
+
+
+@api.route('/notificationsends/<notification_send_id>', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission(Scope.write_notification_sends)
+@jsonp
+def update_notification_send(notification_send_id):
+    if not request.json:
+        raise ApiError('nothing to change', 400)
+
+    updated = NotificationSend.update(notification_send_id, **request.json)
+    if updated:
+        return jsonify(status='ok', notificationSend=updated.serialize)
+    else:
+        raise ApiError('failed to update notificationsend', 500)
+
+
+@api.route('/notificationsends/<notification_channel_id>/send', methods=['OPTIONS', 'POST'])
+@cross_origin()
+@permission(Scope.write_notification_sends)
+@jsonp
+def notification_send(notification_channel_id):
+    notification_channel = NotificationChannel.find_by_id(notification_channel_id)
+    data = request.json
+    users = [User.find_by_email(notification['id']).id for notification in data['notifications'] if notification['type'] == 'User']
+    groups = [notification['id'] for notification in data['notifications'] if notification['type'] == 'Group']
+    try:
+        notification_rule = NotificationRule.parse({'userIds': users, 'groupIds': groups, 'receivers': [], 'text': data['text'], 'channelId': notification_channel_id, 'environment': plugins.config.get('DEFAULT_ENVIRONMENT')})
+    except Exception as e:
+        raise ApiError(str(e), 400)
+    try:
+        handle_test(notification_channel, notification_rule, plugins.config)
+    except Exception as e:
+        raise ApiError(str(e), 500)
+
+    return jsonify(status='ok')


### PR DESCRIPTION
**Description**
Add a notification send for sending custom sms and mail.

**Changes**
- add db table for saving which users that receive the custom mail/sms.
- add api route for sending custom mail through a notification channel
- add api route for reading users and notification groups used for sending custom sms/mail
- add api route for upating wether user is going to receive/read custom mail/sms