### PR TITLE
refac: remove leading and trailing whitespaces from tags

### DIFF
--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -62,7 +62,7 @@ class Alert:
         self.group = kwargs.get('group', None) or 'Misc'
         self.value = kwargs.get('value', None)
         self.text = kwargs.get('text', None) or ''
-        self.tags = kwargs.get('tags', None) or list()
+        self.tags = [tag.strip() for tag in kwargs.get('tags', None) or list()]
         self.attributes = kwargs.get('attributes', None) or dict()
         self.origin = kwargs.get('origin', None) or f'{os.path.basename(sys.argv[0])}/{platform.uname()[1]}'
         self.event_type = kwargs.get('event_type', kwargs.get('type', None)) or 'exceptionAlert'

--- a/alerta/models/blackout.py
+++ b/alerta/models/blackout.py
@@ -48,7 +48,7 @@ class Blackout:
         self.resource = kwargs.get('resource', None)
         self.event = kwargs.get('event', None)
         self.group = kwargs.get('group', None)
-        self.tags = kwargs.get('tags', None) or list()
+        self.tags = list({tag.strip() for tag in kwargs.get('tags', None) or list()})
         self.origin = kwargs.get('origin', None)
         self.customer = kwargs.get('customer', None)
         self.start_time = start_time
@@ -124,7 +124,7 @@ class Blackout:
             'resource': self.resource,
             'event': self.event,
             'group': self.group,
-            'tags': self.tags,
+            'tags': list(self.tags),
             'origin': self.origin,
             'customer': self.customer,
             'startTime': self.start_time,

--- a/alerta/models/notification_rule.py
+++ b/alerta/models/notification_rule.py
@@ -17,8 +17,8 @@ JSON = Dict[str, Any]
 
 class AdvancedTags:
     def __init__(self, all: 'list[str]', any: 'list[str]') -> None:
-        self.all = all or []
-        self.any = any or []
+        self.all = list({a.strip() for a in all})
+        self.any = list({a.strip() for a in any})
 
     @property
     def serialize(self):


### PR DESCRIPTION
**Description**
Remove leading and trailing whitespaces from tags.

**Changes**
- remove leading and trailing whitespaces from tags in alerts
- remove leading and trailing whitespaces from tags in blackouts
- remove leading and trailing whitespaces from tags in advanced tags (notification/escalation rules)
