### PR TITLE
Feat: add query to show alerts history based on environment filter

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -566,9 +566,9 @@ class Backend(Database):
             ) for h in self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
         ]
 
-    def get_history_count(self):
-        query = Query()
-        select = f"SELECT count(*) FROM alerts, unnest(history[1:{current_app.config['HISTORY_LIMIT']}]) h"
+    def get_history_count(self, query=None):
+        query = query or Query()
+        select = f"SELECT count(*) FROM alerts, unnest(history[1:{current_app.config['HISTORY_LIMIT']}]) h WHERE {query.where}"
         return self._fetchone(select, query.vars)
 
     # COUNTS

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -571,6 +571,15 @@ class Backend(Database):
         select = f"SELECT count(*) FROM alerts, unnest(history[1:{current_app.config['HISTORY_LIMIT']}]) h WHERE {query.where}"
         return self._fetchone(select, query.vars)
 
+    def get_history_environment_count(self, query=None):
+        query = query or Query()
+        select = f"""
+            SELECT environment, count(1) FROM alerts, unnest(history[1:{current_app.config['HISTORY_LIMIT']}]) h
+            WHERE {query.where}
+            GROUP BY environment
+        """
+        return self._fetchall(select, query.vars)
+
     # COUNTS
 
     def get_count(self, query=None):

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -182,6 +182,12 @@ class Database(Base):
     def get_history(self, query=None, page=None, page_size=None):
         raise NotImplementedError
 
+    def get_history_count(self, query=None):
+        raise NotImplementedError
+
+    def get_history_environment_count(self, query=None):
+        raise NotImplementedError
+
     # COUNTS
 
     def get_count(self, query=None):

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -511,6 +511,9 @@ class Alert:
     def get_history_count(query=None):
         return db.get_history_count(query).count
 
+    def get_history_environment_count(query=None):
+        return db.get_history_environment_count(query)
+
     # get total count
     @staticmethod
     def get_count(query: Query = None) -> Dict[str, Any]:

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -508,8 +508,8 @@ class Alert:
     def get_history(query: Query = None, page=1, page_size=1000) -> List[RichHistory]:
         return [RichHistory.from_db(hist) for hist in db.get_history(query, page, page_size)]
 
-    def get_history_count():
-        return db.get_history_count().count
+    def get_history_count(query=None):
+        return db.get_history_count(query).count
 
     # get total count
     @staticmethod

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -395,10 +395,12 @@ def history():
 def history_count():
     query = qb.alerts.from_params(request.args, customers=g.customers)
     total = Alert.get_history_count(query)
+    environments = Alert.get_history_environment_count(query)
 
     return jsonify(
         status='ok',
-        total=total
+        total=total,
+        environments={key:value for key,value in environments}
     )
 
 

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -387,6 +387,21 @@ def history():
         )
 
 
+@api.route('/alerts/history/count', methods=['OPTIONS', 'GET'])
+@cross_origin()
+@permission(Scope.read_alerts)
+@timer(gets_timer)
+@jsonp
+def history_count():
+    query = qb.alerts.from_params(request.args, customers=g.customers)
+    total = Alert.get_history_count(query)
+
+    return jsonify(
+        status='ok',
+        total=total
+    )
+
+
 # severity counts
 # status counts
 @api.route('/alerts/count', methods=['OPTIONS', 'GET'])

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -363,7 +363,7 @@ def search_alerts():
 @jsonp
 def history():
     query = qb.alerts.from_params(request.args, customers=g.customers)
-    total = Alert.get_history_count()
+    total = Alert.get_history_count(query)
     paging = Page.from_params(request.args, total)
     try:
         history = Alert.get_history(query, paging.page, paging.page_size)


### PR DESCRIPTION
**Description**
Add query to alerts history for environments filter

**Changes**
- add api endpoint(view) for environment history counts
- add query to history to enable possibility to show alerts based on environments, resource, etc