### PR TITLE
fix: remove group ids when deleting notification group

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1138,6 +1138,13 @@ class Backend(Database):
         )
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
 
+    def get_notification_rules_by_notification_group(self, group_id):
+        select = """
+            SELECT id, name FROM notification_rules
+            WHERE %(group_id)s = ANY(group_ids)
+        """
+        return self._fetchall(select, {'group_id': group_id})
+
     def get_notification_rules_count(self, query=None):
         query = query or Query()
         select = """
@@ -1468,6 +1475,12 @@ class Backend(Database):
             WHERE id=%s
             RETURNING id
         """
+        update = """
+            UPDATE notification_rules
+            SET group_ids = ARRAY_REMOVE(group_ids, %(id)s)
+            WHERE %(id)s = ANY(group_ids)
+        """
+        self._updateall(update, {'id': id}, returning=False)
         return self._deleteone(delete, (id,), returning=True)
 
 # NOTIFICATION SEND

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -319,6 +319,9 @@ class Database(Base):
     def get_notification_rules(self, query=None, page=None, page_size=None):
         raise NotImplementedError
 
+    def get_notification_rules_by_notification_group(self, group_id: str):
+        raise NotImplementedError
+
     def get_notification_rules_count(self, query=None):
         raise NotImplementedError
 

--- a/alerta/models/notification_group.py
+++ b/alerta/models/notification_group.py
@@ -16,7 +16,7 @@ class NotificationGroup:
         self.phone_numbers = kwargs.get('phone_numbers', [])
         self.mails = kwargs.get('mails', [])
 
-    @ classmethod
+    @classmethod
     def parse(cls, json: JSON) -> 'NotificationGroup':
         if not isinstance(json.get('users', []), list):
             raise ValueError('users must be a list')
@@ -32,7 +32,7 @@ class NotificationGroup:
         )
         return notification_group
 
-    @ property
+    @property
     def serialize(self) -> Dict[str, Any]:
         return {
             'id': self.id,
@@ -51,7 +51,7 @@ class NotificationGroup:
             self.mails,
         )
 
-    @ classmethod
+    @classmethod
     def from_document(cls, doc: Dict[str, Any]) -> 'NotificationGroup':
         return NotificationGroup(
             id=doc.get('id', None) or doc.get('_id'),
@@ -61,7 +61,7 @@ class NotificationGroup:
             mails=doc.get('mails'),
         )
 
-    @ classmethod
+    @classmethod
     def from_record(cls, rec) -> 'NotificationGroup':
         return NotificationGroup(
             id=rec.id,
@@ -71,7 +71,7 @@ class NotificationGroup:
             mails=rec.mails,
         )
 
-    @ classmethod
+    @classmethod
     def from_db(cls, r: Union[Dict, Tuple]) -> 'NotificationGroup':
         if isinstance(r, dict):
             return cls.from_document(r)
@@ -83,15 +83,15 @@ class NotificationGroup:
         return NotificationGroup.from_db(db.create_notification_group(self))
 
     # get a notification rule
-    @ staticmethod
+    @staticmethod
     def find_by_id(id: str, customers: List[str] = None) -> Optional['NotificationGroup']:
         return NotificationGroup.from_db(db.get_notification_group(id))
 
-    @ staticmethod
+    @staticmethod
     def find_all(query: Query = None, page: int = 1, page_size: int = 1000) -> List['NotificationGroup']:
         return [NotificationGroup.from_db(notification_group) for notification_group in db.get_notification_groups(query, page, page_size)]
 
-    @ staticmethod
+    @staticmethod
     def count(query: Query = None) -> int:
         return db.get_notification_groups_count(query)
 

--- a/alerta/models/notification_rule.py
+++ b/alerta/models/notification_rule.py
@@ -214,9 +214,11 @@ class NotificationRule:
     @property
     def users(self):
         groups = [NotificationGroup.find_by_id(group_id) for group_id in self.group_ids]
-        group_users = [db.get_notification_group_users(group.id) for group in groups]
+        group_users = [db.get_notification_group_users(group.id) for group in groups if group is not None]
         users = {User.find_by_id(user_id).notification_info for user_id in self.user_ids}
         for group in groups:
+            if group is None:
+                continue
             for index in range(max(len(group.phone_numbers), len(group.mails))):
                 users.add(NotificationInfo(phone_number=group.phone_numbers[index] if index < len(group.phone_numbers) else None, email=group.mails[index] if index < len(group.mails) else None))
         for user_list in group_users:
@@ -438,6 +440,12 @@ class NotificationRule:
         return [
             NotificationRule.from_db(notification_rule)
             for notification_rule in db.get_notification_rules(query, page, page_size)
+        ]
+
+    @staticmethod
+    def find_all_by_notification_group(group_id: str) -> List['NotificationRule']:
+        return [
+            {'id': notification_rule.id, 'name': notification_rule.name}for notification_rule in db.get_notification_rules_by_notification_group(group_id)
         ]
 
     @staticmethod

--- a/alerta/views/notification_rules.py
+++ b/alerta/views/notification_rules.py
@@ -174,6 +174,32 @@ def get_notification_rules_activestatus():
     return jsonify(status='ok', total=total, notificationRules=notification_rules)
 
 
+@api.route('/notificationrules/group/<group_id>', methods=['OPTIONS', 'GET'])
+@cross_origin()
+@permission(Scope.read_notification_rules)
+@jsonp
+def list_notification_rules_by_notification_group(group_id):
+    try:
+        notification_rules = NotificationRule.find_all_by_notification_group(group_id)
+    except (UndefinedColumn, CannotCoerce) as e:
+        e.cursor.connection.rollback()
+        current_app.logger.info(f'Notification rule search failed with message: {e.diag.message_primary}. HINT: {e.diag.message_hint}')
+        return jsonify(status='error', name='Notification Search', message=f'{e.diag.message_primary}. HINT: {e.diag.message_hint}'), 400
+
+    if notification_rules:
+        return jsonify(
+            status='ok',
+            notificationRules=notification_rules,
+        )
+    else:
+        return jsonify(
+            status='ok',
+            message='not found',
+            notificationRules=[],
+            total=0,
+        )
+
+
 @api.route('/notificationrules', methods=['OPTIONS', 'GET'])
 @cross_origin()
 @permission(Scope.read_notification_rules)


### PR DESCRIPTION
**Description**
Remove notification group id from all notification rules when the group is deleted

**Changes**
- Add api view to see the notification rules that refer to a notification group ID
- Add a database query that removes the notification group ID from all notification rules when the group is deleted
- Fix the check for the notification group when trying to get users in the notification rule plugin
