### PR TITLE
feat: add new tagging structure for alerts

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -266,7 +266,7 @@ class Backend(Database):
                SET status=%(status)s, service=%(service)s, value=%(value)s, text=%(text)s,
                    timeout=%(timeout)s, raw_data=%(raw_data)s, repeat=%(repeat)s,
                    last_receive_id=%(last_receive_id)s, last_receive_time=%(last_receive_time)s,
-                   tags=ARRAY(SELECT DISTINCT UNNEST(tags || %(tags)s)), attributes=attributes || %(attributes)s,
+                   tags=%(tags)s, attributes=attributes || %(attributes)s,
                    duplicate_count=duplicate_count + 1, {update_time}, history=(%(history)s || history)[1:{limit}]
              WHERE environment=%(environment)s
                AND resource=%(resource)s
@@ -289,7 +289,7 @@ class Backend(Database):
                    text=%(text)s, create_time=%(create_time)s, timeout=%(timeout)s, raw_data=%(raw_data)s,
                    duplicate_count=%(duplicate_count)s, repeat=%(repeat)s, previous_severity=%(previous_severity)s,
                    trend_indication=%(trend_indication)s, receive_time=%(receive_time)s, last_receive_id=%(last_receive_id)s,
-                   last_receive_time=%(last_receive_time)s, tags=ARRAY(SELECT DISTINCT UNNEST(tags || %(tags)s)),
+                   last_receive_time=%(last_receive_time)s, tags=%(tags)s,
                    attributes=attributes || %(attributes)s, {update_time}, history=(%(history)s || history)[1:{limit}]
              WHERE environment=%(environment)s
                AND resource=%(resource)s
@@ -321,7 +321,7 @@ class Backend(Database):
     def set_alert(self, id, severity, status, tags, attributes, timeout, previous_severity, update_time, history=None):
         update = """
             UPDATE alerts
-               SET severity=%(severity)s, status=%(status)s, tags=ARRAY(SELECT DISTINCT UNNEST(tags || %(tags)s)),
+               SET severity=%(severity)s, status=%(status)s, tags=%(tags)s,
                    attributes=%(attributes)s, timeout=%(timeout)s, previous_severity=%(previous_severity)s,
                    update_time=%(update_time)s, history=(%(change)s || history)[1:{limit}]
              WHERE id=%(id)s OR id LIKE %(like_id)s
@@ -354,7 +354,7 @@ class Backend(Database):
     def tag_alert(self, id, tags):
         update = """
             UPDATE alerts
-            SET tags=ARRAY(SELECT DISTINCT UNNEST(tags || %(tags)s))
+            SET tags=%(tags)s
             WHERE id=%(id)s OR id LIKE %(like_id)s
             RETURNING *
         """

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -63,6 +63,7 @@ class Alert:
         self.value = kwargs.get('value', None)
         self.text = kwargs.get('text', None) or ''
         self.tags = kwargs.get('tags', None) or list()
+        self.tags = list(set(self.tags))
         self.custom_tags = kwargs.get('custom_tags', None) or list()
         self.attributes = kwargs.get('attributes', None) or dict()
         self.origin = kwargs.get('origin', None) or f'{os.path.basename(sys.argv[0])}/{platform.uname()[1]}'

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -63,6 +63,7 @@ class Alert:
         self.value = kwargs.get('value', None)
         self.text = kwargs.get('text', None) or ''
         self.tags = kwargs.get('tags', None) or list()
+        self.custom_tags = kwargs.get('custom_tags', None) or list()
         self.attributes = kwargs.get('attributes', None) or dict()
         self.origin = kwargs.get('origin', None) or f'{os.path.basename(sys.argv[0])}/{platform.uname()[1]}'
         self.event_type = kwargs.get('event_type', kwargs.get('type', None)) or 'exceptionAlert'
@@ -136,6 +137,7 @@ class Alert:
             'value': self.value,
             'text': self.text,
             'tags': self.tags,
+            'customTags': self.custom_tags,
             'attributes': self.attributes,
             'origin': self.origin,
             'type': self.event_type,
@@ -186,6 +188,7 @@ class Alert:
             value=doc.get('value', None),
             text=doc.get('text', None),
             tags=doc.get('tags', list()),
+            custom_tags=doc.get('custom_tags', list()),
             attributes=doc.get('attributes', dict()),
             origin=doc.get('origin', None),
             event_type=doc.get('type', None),
@@ -219,6 +222,7 @@ class Alert:
             value=rec.value,
             text=rec.text,
             tags=rec.tags,
+            custom_tags=rec.custom_tags,
             attributes=dict(rec.attributes),
             origin=rec.origin,
             event_type=rec.type,

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS alerts (
 );
 
 ALTER TABLE alerts ADD COLUMN IF NOT EXISTS update_time timestamp without time zone;
+ALTER TABLE alerts ADD COLUMN IF NOT EXISTS custom_tags text[];
 
 -- remove alerts with status set to null
 DO $$

--- a/alerta/utils/hooks.py
+++ b/alerta/utils/hooks.py
@@ -41,7 +41,7 @@ class HookTrigger:
         except Exception as e:
             raise ApiError(str(e), 500)
 
-        alert.tag(alert.tags)
+        # alert.tag(alert.tags)
         alert.attributes = alert.update_attributes(alert.attributes)
 
         return alert, status, text

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -503,14 +503,15 @@ class AlertsTestCase(unittest.TestCase):
 
         alert_id = data['id']
 
-        # append tag to existing
+        # append tag to customTags
         response = self.client.put('/alert/' + alert_id + '/tag',
                                    data=json.dumps({'tags': ['bar']}), headers=self.headers)
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/alert/' + alert_id)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(sorted(data['alert']['tags']), ['bar', 'foo'])
+        # added tag is the only tag in customTags
+        self.assertEqual(sorted(data['alert']['customTags']), ['bar'])
 
         # duplicate tag is a no-op
         response = self.client.put('/alert/' + alert_id + '/tag',
@@ -519,16 +520,16 @@ class AlertsTestCase(unittest.TestCase):
         response = self.client.get('/alert/' + alert_id)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(sorted(data['alert']['tags']), ['bar', 'foo'])
+        self.assertEqual(sorted(data['alert']['customTags']), ['bar'])
 
         # delete tag
         response = self.client.put('/alert/' + alert_id + '/untag',
-                                   data=json.dumps({'tags': ['foo']}), headers=self.headers)
+                                   data=json.dumps({'tags': ['bar']}), headers=self.headers)
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/alert/' + alert_id)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['tags'], ['bar'])
+        self.assertEqual(data['alert']['customTags'], [])
 
     def test_alert_no_attributes(self):
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -132,7 +132,7 @@ class PluginsTestCase(unittest.TestCase):
         response = self.client.post('/alert', json=self.critical_alert, headers=self.headers)
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['tags'], ['Production', 'Staging', 'Development'])
+        self.assertEqual(sorted(data['alert']['tags']), sorted(['Production', 'Staging', 'Development']))
         self.assertEqual(data['alert']['attributes'], {'aaa': 'post1', 'ip': '127.0.0.1', 'old': 'post1'})
 
         alert_id = data['id']

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -72,10 +72,11 @@ class TagsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
         self.assertIn(alert_id, data['alert']['id'])
-        self.assertEqual(sorted(data['alert']['tags']), sorted(['foo', 'bar', 'baz']))
+        self.assertEqual(sorted(data['alert']['tags']), sorted(['foo']))
+        self.assertEqual(sorted(data['alert']['customTags']), sorted(['bar', 'baz']))
         self.assertEqual(data['alert']['duplicateCount'], 1)
 
-        # tag alert
+        # add customTag alert
         response = self.client.put('/alert/%s/tag' %
                                    alert_id, data=json.dumps({'tags': ['quux']}), headers=self.headers)
         self.assertEqual(response.status_code, 200)
@@ -92,6 +93,7 @@ class TagsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertIn('tagged', sorted(data['alert']['tags']))
+        self.assertNotIn('tagged', sorted(data['alert']['customTags']))
 
         # untag user operator action
         response = self.client.put('/alert/' + alert_id + '/action', json=payload, headers=self.headers)
@@ -107,7 +109,8 @@ class TagsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
         self.assertIn(alert_id, data['alert']['id'])
-        self.assertEqual(sorted(data['alert']['tags']), sorted(['foo', 'bar', 'baz', 'quux']))
+        self.assertEqual(sorted(data['alert']['tags']), sorted(['foo']))
+        self.assertEqual(sorted(data['alert']['customTags']), sorted(['bar', 'baz', 'quux']))
 
         # untag alert
         response = self.client.put('/alert/%s/untag' %
@@ -119,7 +122,8 @@ class TagsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
         self.assertIn(alert_id, data['alert']['id'])
-        self.assertEqual(sorted(data['alert']['tags']), sorted(['foo', 'bar', 'baz']))
+        self.assertEqual(sorted(data['alert']['tags']), sorted(['foo']))
+        self.assertEqual(sorted(data['alert']['customTags']), sorted(['bar', 'baz']))
 
         del plugins.plugins['tag']
 


### PR DESCRIPTION
**Description**
Always update alert tags when receiving alerts, and add custom tags to support tag/untag

**Changes**
- Alert tags are always updated when receiving an alert
- add custom tags that are only updated by tag/untag
