### PR TITLE
fix: get user_email instead of relying on ID to be correct

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1518,6 +1518,10 @@ class Backend(Database):
         select = 'SELECT * FROM notification_sends'
         return self._fetchall(select, [])
 
+    def get_notification_send(self, id: str):
+        select = """SELECT * from notification_sends WHERE id=%(id)s"""
+        return self._fetchone(select, {'id': id})
+
     def update_notification_send(self, id, **kwargs):
         update = """
             UPDATE notification_sends

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -373,6 +373,9 @@ class Database(Base):
     def get_notification_sends(self):
         raise NotImplementedError
 
+    def get_notification_send(self, id: str):
+        raise NotImplementedError
+
     def update_notification_send(self, id, **kwargs):
         raise NotImplementedError
 

--- a/alerta/models/notification_send.py
+++ b/alerta/models/notification_send.py
@@ -65,3 +65,24 @@ class NotificationSend:
     @staticmethod
     def update(id, **kwargs) -> 'NotificationSend':
         return NotificationSend.from_db(db.update_notification_send(id, **kwargs))
+
+
+class NotificationSendInfo(NotificationSend):
+    def __init__(self, **kwargs):
+        NotificationSend.__init__(self, **kwargs)
+        self.email = kwargs.get('email')
+
+    @classmethod
+    def from_db(cls, r: Tuple):
+        return NotificationSendInfo(
+            id=r.id,
+            user_name=r.user_name,
+            group_name=r.group_name,
+            mail=r.mail,
+            sms=r.sms,
+            email=r.user_email
+        )
+
+    @staticmethod
+    def find_by_id(id: str) -> 'NotificationSendInfo':
+        return NotificationSendInfo.from_db(db.get_notification_send(id))

--- a/alerta/views/notification_sends.py
+++ b/alerta/views/notification_sends.py
@@ -7,7 +7,8 @@ from alerta.exceptions import ApiError
 from alerta.models.enums import Scope
 from alerta.models.notification_channel import NotificationChannel
 from alerta.models.notification_rule import NotificationRule
-from alerta.models.notification_send import NotificationSend
+from alerta.models.notification_send import (NotificationSend,
+                                             NotificationSendInfo)
 from alerta.plugins.notification_rule import handle_test
 from alerta.utils.response import jsonp
 
@@ -58,7 +59,7 @@ def update_notification_send(notification_send_id):
 def notification_send(notification_channel_id):
     notification_channel = NotificationChannel.find_by_id(notification_channel_id)
     data = request.json
-    users = [notification['id'] for notification in data['notifications'] if notification['type'] == 'User']
+    users = [NotificationSendInfo.find_by_id(notification['id']).email for notification in data['notifications'] if notification['type'] == 'User']
     groups = [notification['id'] for notification in data['notifications'] if notification['type'] == 'Group']
     try:
         notification_rule = NotificationRule.parse({'usersEmails': users, 'groupIds': groups, 'receivers': [], 'text': data['text'], 'channelId': notification_channel_id, 'environment': plugins.config.get('DEFAULT_ENVIRONMENT')})


### PR DESCRIPTION
**Description**
Get user_email from the database instead of relying on the ID of notification sends to be correct. The user_email is a reference to the actual users table and will never be wrong, while the notification send ID does not update when the user email is updated in the users table
