### PR TITLE
feat: add export of manual setup

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -827,6 +827,8 @@ class Backend(Database):
              WHERE {where}
           ORDER BY {order}
         """.format(where=query.where, order=query.sort)
+        if page_size == 'ALL':
+            return self._fetchall(select, query.vars, limit=page_size)
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
 
     def get_blackouts_count(self, query=None):
@@ -991,6 +993,8 @@ class Backend(Database):
         """.format(
             where=query.where, order=query.sort
         )
+        if page_size == 'ALL':
+            return self._fetchall(select, query.vars, limit=page_size)
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
 
     def get_notification_channels_count(self, query=None):
@@ -1139,6 +1143,8 @@ class Backend(Database):
         """.format(
             where=query.where, order=query.sort
         )
+        if page_size == 'ALL':
+            return self._fetchall(select, query.vars, limit=page_size)
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
 
     def get_notification_rules_by_notification_group(self, group_id):
@@ -1432,6 +1438,8 @@ class Backend(Database):
         """.format(
             where=query.where, order=query.sort if query.sort != '(select 1)' else 'name'
         )
+        if page_size == 'ALL':
+            return self._fetchall(select, query.vars, limit=page_size)
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
 
     def get_notification_group_users(self, id):
@@ -1618,6 +1626,8 @@ class Backend(Database):
         """.format(
             where=query.where, order=query.sort
         )
+        if page_size == 'ALL':
+            return self._fetchall(select, query.vars, limit=page_size)
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
 
     def get_escalation_rules_count(self, query=None):
@@ -1747,6 +1757,8 @@ class Backend(Database):
         """.format(
             where=query.where, order=query.sort
         )
+        if page_size == 'ALL':
+            return self._fetchall(select, query.vars, limit=page_size)
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size if page else None)
 
     def get_on_calls_count(self, query=None):
@@ -1943,6 +1955,8 @@ class Backend(Database):
              WHERE {query.where}
           ORDER BY {query.sort}
         """
+        if page_size == 'ALL':
+            return self._fetchall(select, query.vars, limit=page_size)
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
 
     def get_keys_by_user(self, user):
@@ -2242,6 +2256,8 @@ class Backend(Database):
              WHERE {query.where}
           ORDER BY {query.sort}
         """
+        if page_size == 'ALL':
+            return self._fetchall(select, query.vars, limit=page_size)
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
 
     def get_perms_count(self, query=None):
@@ -2316,6 +2332,8 @@ class Backend(Database):
              WHERE {query.where}
           ORDER BY {query.sort}
         """
+        if page_size == 'ALL':
+            return self._fetchall(select, query.vars, limit=page_size)
         return self._fetchall(select, query.vars, limit=page_size, offset=(page - 1) * page_size)
 
     def get_customers_count(self, query=None):

--- a/alerta/models/enums.py
+++ b/alerta/models/enums.py
@@ -59,6 +59,7 @@ class Scope(str):
     read = 'read'
     write = 'write'
     admin = 'admin'
+    admin_alerta = 'admin:alerta'
     read_alerts = 'read:alerts'
     write_alerts = 'write:alerts'
     delete_alerts = 'delete:alerts'

--- a/alerta/models/key.py
+++ b/alerta/models/key.py
@@ -60,6 +60,22 @@ class ApiKey:
 
         return api_key
 
+    @classmethod
+    def _import(cls, json: JSON) -> 'ApiKey':
+        if not isinstance(json.get('scopes', []), list):
+            raise ValueError('scopes must be a list')
+
+        api_key = ApiKey(
+            id=json.get('id', None),
+            user=json.get('user', None),
+            scopes=[Scope(s) for s in json.get('scopes', [])],
+            text=json.get('text', None),
+            expire_time=DateTime.parse(json['expireTime']) if 'expireTime' in json else None,
+            customer=json.get('customer', None),
+            key=json.get('key')
+        )
+        return api_key
+
     @property
     def serialize(self) -> Dict[str, Any]:
         return {

--- a/alerta/models/notification_channel.py
+++ b/alerta/models/notification_channel.py
@@ -60,6 +60,37 @@ class NotificationChannel:
             'verify': self.verify
         }
 
+    @classmethod
+    def _import(cls, json: JSON) -> 'NotificationChannel':
+        return NotificationChannel(
+            id=json.get('id', None),
+            _type=json['type'],
+            api_token=json['apiToken'],
+            api_sid=json['apiSid'],
+            sender=json['sender'],
+            host=json.get('host', None),
+            platform_id=json.get('platfromId', None),
+            platform_partner_id=json.get('platfromPartnerId', None),
+            customer=json.get('customer', None),
+            verify=json.get('verify', None),
+        )
+
+    @property
+    def export(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'href': absolute_url('/notificationchannel/' + self.id),
+            'type': self.type,
+            'sender': self.sender,
+            'customer': self.customer,
+            'host': self.host,
+            'platformId': self.platform_id,
+            'platformPartnerId': self.platform_partner_id,
+            'verify': self.verify,
+            'apiSid': self.api_sid,
+            'apiToken': self.api_token
+        }
+
     def __repr__(self) -> str:
         more = ''
         if self.customer:

--- a/alerta/views/__init__.py
+++ b/alerta/views/__init__.py
@@ -7,7 +7,7 @@ from alerta.utils.response import absolute_url
 
 api = Blueprint('api', __name__)
 
-from . import alerts, blackouts, config, customers, groups, keys, oembed, permissions, users, notification_rules, notification_channels, notification_history, on_call, escalation_rules, notification_groups, notification_delays, notification_sends  # noqa isort:skip
+from . import alerta, alerts, blackouts, config, customers, groups, keys, oembed, permissions, users, notification_rules, notification_channels, notification_history, on_call, escalation_rules, notification_groups, notification_delays, notification_sends  # noqa isort:skip
 if get_config('HEARTBEAT_URL') is None:
     from . import heartbeats  # noqa
 else:

--- a/alerta/views/alerta.py
+++ b/alerta/views/alerta.py
@@ -1,0 +1,145 @@
+from flask import jsonify, request
+from alerta.auth.decorators import permission
+
+from alerta.models.escalation_rule import EscalationRule
+from alerta.models.notification_rule import NotificationRule, NotificationChannel, NotificationGroup
+from alerta.models.on_call import OnCall
+from alerta.models.blackout import Blackout
+from alerta.models.user import User
+from alerta.models.enums import Scope
+from alerta.models.customer import Customer
+from alerta.models.permission import Permission
+from alerta.models.key import ApiKey
+
+from psycopg2.errors import UniqueViolation
+
+from alerta.utils.response import jsonp
+
+from . import api
+
+
+@api.route('/export', methods=['GET'])
+@permission(Scope.admin_alerta)
+def export():
+    escalation_rules = [item.serialize for item in EscalationRule.find_all()]
+    notification_rules = [item.serialize for item in NotificationRule.find_all()]
+    notification_channels = [item.export for item in NotificationChannel.find_all()]
+    blackouts = [item.serialize for item in Blackout.find_all()]
+    notification_groups = [item.serialize for item in NotificationGroup.find_all()]
+    on_calls = [item.serialize for item in OnCall.find_all()]
+    users = [item.serialize for item in User.find_all()]
+    perms = [item.serialize for item in Permission.find_all()]
+    keys = [item.serialize for item in ApiKey.find_all()]
+    customers = [item.serialize for item in Customer.find_all()]
+
+    return jsonify(
+        escalationRules=escalation_rules,
+        notificationRules=notification_rules,
+        notificationChannels=notification_channels,
+        blackouts=blackouts,
+        notificationGroups=notification_groups,
+        onCalls=on_calls,
+        users=users,
+        perms=perms,
+        keys=keys,
+        customers=customers
+    )
+
+
+@api.route('/import', methods=['POST'])
+@permission(Scope.admin_alerta)
+@jsonp
+def import_all():
+    data = request.json
+    users = []
+    for user in data.get('users'):
+        try:
+            users.append(User.parse(user).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    perms = []
+    for perm in data.get('perms'):
+        try:
+            perms.append(Permission.parse(perm).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    keys = []
+    for key in data.get('keys'):
+        try:
+            keys.append(ApiKey._import(key).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    customers = []
+    for customer in data.get('customers'):
+        try:
+            customers.append(Customer.parse(customer).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    blackouts = []
+    for blackout in data.get('blackouts'):
+        try:
+            blackouts.append(Blackout.parse(blackout).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    escalation_rules = []
+    for rule in data.get('escalationRules'):
+        try:
+            escalation_rules.append(EscalationRule.parse(rule).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    notification_channels = []
+    for channel in data.get('notificationChannels'):
+        try:
+            notification_channels.append(NotificationChannel._import(channel).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    notification_groups = []
+    for group in data.get('notificationGroups'):
+        try:
+            notification_groups.append(NotificationGroup.parse(group).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    on_calls = []
+    for on_call in data.get('onCalls'):
+        try:
+            on_calls.append(OnCall.parse(on_call).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    notification_rules = []
+    for rule in data.get('notificationRules'):
+        try:
+            notification_rules.append(NotificationRule.parse(rule).create())
+        except UniqueViolation as pg_error:
+            pg_error.cursor.connection.rollback()
+            continue
+
+    return jsonify(
+        escalationRules=[item.serialize for item in escalation_rules],
+        notificationRules=[item.serialize for item in notification_rules],
+        notificationChannels=[item.serialize for item in notification_channels],
+        blackouts=[item.serialize for item in blackouts],
+        notificationGroups=[item.serialize for item in notification_groups],
+        onCalls=[item.serialize for item in on_calls],
+        users=[item.serialize for item in users],
+        perms=[item.serialize for item in perms],
+        keys=[item.serialize for item in keys],
+        customers=[item.serialize for item in customers]
+    )

--- a/alerta/views/alerta.py
+++ b/alerta/views/alerta.py
@@ -20,15 +20,15 @@ from . import api
 @api.route('/export', methods=['GET'])
 @permission(Scope.admin_alerta)
 def export():
-    escalation_rules = [item.serialize for item in EscalationRule.find_all()]
-    notification_rules = [item.serialize for item in NotificationRule.find_all()]
-    notification_channels = [item.export for item in NotificationChannel.find_all()]
-    blackouts = [item.serialize for item in Blackout.find_all()]
-    notification_groups = [item.serialize for item in NotificationGroup.find_all()]
-    on_calls = [item.serialize for item in OnCall.find_all()]
-    perms = [item.serialize for item in Permission.find_all()]
-    keys = [item.serialize for item in ApiKey.find_all()]
-    customers = [item.serialize for item in Customer.find_all()]
+    escalation_rules = [item.serialize for item in EscalationRule.find_all(page_size='ALL')]
+    notification_rules = [item.serialize for item in NotificationRule.find_all(page_size='ALL')]
+    notification_channels = [item.export for item in NotificationChannel.find_all(page_size='ALL')]
+    blackouts = [item.serialize for item in Blackout.find_all(page_size='ALL')]
+    notification_groups = [item.serialize for item in NotificationGroup.find_all(page_size='ALL')]
+    on_calls = [item.serialize for item in OnCall.find_all(page_size='ALL')]
+    perms = [item.serialize for item in Permission.find_all(page_size='ALL')]
+    keys = [item.serialize for item in ApiKey.find_all(page_size='ALL')]
+    customers = [item.serialize for item in Customer.find_all(page_size='ALL')]
 
     return jsonify(
         escalationRules=escalation_rules,
@@ -39,7 +39,18 @@ def export():
         onCalls=on_calls,
         perms=perms,
         keys=keys,
-        customers=customers
+        customers=customers,
+        total={
+            'escalationRules': len(escalation_rules),
+            'notificationRules': len(notification_rules),
+            'notificationChannels': len(notification_channels),
+            'blackouts': len(blackouts),
+            'notificationGroups': len(notification_groups),
+            'onCalls': len(on_calls),
+            'perms': len(perms),
+            'keys': len(keys),
+            'customers': len(customers),
+        }
     )
 
 
@@ -130,5 +141,16 @@ def import_all():
         onCalls=[item.serialize for item in on_calls],
         perms=[item.serialize for item in perms],
         keys=[item.serialize for item in keys],
-        customers=[item.serialize for item in customers]
+        customers=[item.serialize for item in customers],
+        total={
+            'escalationRules': len(escalation_rules),
+            'notificationRules': len(notification_rules),
+            'notificationChannels': len(notification_channels),
+            'blackouts': len(blackouts),
+            'notificationGroups': len(notification_groups),
+            'onCalls': len(on_calls),
+            'perms': len(perms),
+            'keys': len(keys),
+            'customers': len(customers),
+        }
     )

--- a/alerta/views/alerta.py
+++ b/alerta/views/alerta.py
@@ -1,18 +1,17 @@
 from flask import jsonify, request
-from alerta.auth.decorators import permission
-
-from alerta.models.escalation_rule import EscalationRule
-from alerta.models.notification_rule import NotificationRule, NotificationChannel, NotificationGroup
-from alerta.models.on_call import OnCall
-from alerta.models.blackout import Blackout
-from alerta.models.user import User
-from alerta.models.enums import Scope
-from alerta.models.customer import Customer
-from alerta.models.permission import Permission
-from alerta.models.key import ApiKey
-
 from psycopg2.errors import UniqueViolation
 
+from alerta.auth.decorators import permission
+from alerta.models.blackout import Blackout
+from alerta.models.customer import Customer
+from alerta.models.enums import Scope
+from alerta.models.escalation_rule import EscalationRule
+from alerta.models.key import ApiKey
+from alerta.models.notification_rule import (NotificationChannel,
+                                             NotificationGroup,
+                                             NotificationRule)
+from alerta.models.on_call import OnCall
+from alerta.models.permission import Permission
 from alerta.utils.response import jsonp
 
 from . import api
@@ -27,7 +26,6 @@ def export():
     blackouts = [item.serialize for item in Blackout.find_all()]
     notification_groups = [item.serialize for item in NotificationGroup.find_all()]
     on_calls = [item.serialize for item in OnCall.find_all()]
-    users = [item.serialize for item in User.find_all()]
     perms = [item.serialize for item in Permission.find_all()]
     keys = [item.serialize for item in ApiKey.find_all()]
     customers = [item.serialize for item in Customer.find_all()]
@@ -39,7 +37,6 @@ def export():
         blackouts=blackouts,
         notificationGroups=notification_groups,
         onCalls=on_calls,
-        users=users,
         perms=perms,
         keys=keys,
         customers=customers
@@ -51,13 +48,6 @@ def export():
 @jsonp
 def import_all():
     data = request.json
-    users = []
-    for user in data.get('users'):
-        try:
-            users.append(User.parse(user).create())
-        except UniqueViolation as pg_error:
-            pg_error.cursor.connection.rollback()
-            continue
 
     perms = []
     for perm in data.get('perms'):
@@ -138,7 +128,6 @@ def import_all():
         blackouts=[item.serialize for item in blackouts],
         notificationGroups=[item.serialize for item in notification_groups],
         onCalls=[item.serialize for item in on_calls],
-        users=[item.serialize for item in users],
         perms=[item.serialize for item in perms],
         keys=[item.serialize for item in keys],
         customers=[item.serialize for item in customers]


### PR DESCRIPTION
**Description**
Add export view for exporting/importing all manual configs of Alerta

**Changes**
- Add export/import including:
  - Blackouts
  - Escalation Rules
  - Notification Channels
  - Notification Groups
  - On Calls
  - Notification Rules
  - Permissions
  - API keys
  - Customers
- Add possibility to use page-size=ALL for all exported tables