### PR TITLE
Feat: add bulk action, bulk post alerts, and bulk delete of alerts

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -303,6 +303,120 @@ class Backend(Database):
         )
         return self._updateone(update, vars(alert), returning=True)
 
+    def correlate_multiple_alerts(self, alerts):
+        """
+        Update alert status, service, value, text, timeout and rawData, increment duplicate count and set
+        repeat=True, and keep track of last receive id and time but don't append to history unless status changes.
+        """
+        objs = {}
+        alerts_values = []
+        for i, alert in enumerate(alerts):
+            alerts_values.append(
+                f"""
+                (
+                    %(environment{i})s, %(resource{i})s, %(event{i})s, %(severity{i})s,
+                    %(status{i})s,%(service{i})s, %(value{i})s, %(text{i})s,
+                    %(timeout{i})s, %(raw_data{i})s, %(last_receive_id{i})s, (%(last_receive_time{i})s)::timestamp without time zone,
+                    %(tags{i})s, (%(attributes{i})s)::jsonb, (%(update_time{i})s)::timestamp without time zone,
+                    (%(history{i})s), %(customer{i})s, (%(create_time{i})s)::timestamp without time zone, %(previous_severity{i})s,
+                    %(trend_indication{i})s, (%(receive_time{i})s)::timestamp without time zone, %(duplicate_count{i})s
+                )
+                """
+            )
+            objs.update({f'{key}{i}': value for key, value in vars(alert).items()})
+        update = f"""
+            UPDATE alerts
+               SET event=al.event, severity=al.severity, status=al.status, service=al.service, value=al.value, text=al.text,
+                   create_time=al.create_time, timeout=al.timeout, raw_data=al.raw_data, repeat=FALSE, previous_severity=al.previous_severity,
+                   trend_indication=al.trend_indication, receive_time=al.receive_time, last_receive_id=al.last_receive_id, last_receive_time=al.last_receive_time,
+                   tags=ARRAY(SELECT DISTINCT UNNEST(alerts.tags || al.tags)), attributes=alerts.attributes || al.attributes,
+                   duplicate_count=al.duplicate_count, update_time=COALESCE(al.update_time, alerts.update_time),
+                   history=CASE WHEN al.history IS NULL THEN alerts.history ELSE (al.history || alerts.history)[1:{current_app.config['HISTORY_LIMIT']}] END
+            FROM (VALUES
+                {",".join(alerts_values)}
+                ) as al(
+                    environment, resource, event, severity,
+                    status, service, value, text,
+                    timeout, raw_data, last_receive_id, last_receive_time,
+                    tags, attributes, update_time, history, customer, create_time, previous_severity,
+                    trend_indication, receive_time, duplicate_count
+                )
+             WHERE alerts.environment=al.environment
+               AND alerts.resource=al.resource
+               AND ((alerts.event=al.event AND alerts.severity!=al.severity) OR (alerts.event!=al.event AND al.event=ANY(alerts.correlate)))
+         RETURNING alerts.*
+        """
+        return self._updateall(update, objs, returning=True)
+
+    def dedup_multiple_alerts(self, alerts):
+        """
+        Update alert status, service, value, text, timeout and rawData, increment duplicate count and set
+        repeat=True, and keep track of last receive id and time but don't append to history unless status changes.
+        """
+        objs = {}
+        alerts_values = []
+        for i, alert in enumerate(alerts):
+            alerts_values.append(
+                f"""
+                (
+                    %(environment{i})s, %(resource{i})s, %(event{i})s, %(severity{i})s,
+                    %(status{i})s,%(service{i})s,%(value{i})s, %(text{i})s,
+                    %(timeout{i})s, %(raw_data{i})s, %(last_receive_id{i})s, (%(last_receive_time{i})s)::timestamp without time zone,
+                    %(tags{i})s, (%(attributes{i})s)::jsonb, (%(update_time{i})s)::timestamp without time zone,
+                    (%(history{i})s)::history, %(customer{i})s
+                )
+                """
+            )
+            objs.update({f'{key}{i}': value for key, value in vars(alert).items()})
+        update = f"""
+            UPDATE alerts
+               SET status=al.status, service=al.service, value=al.value, text=al.text,
+                   timeout=al.timeout, raw_data=al.raw_data, repeat=TRUE,
+                   last_receive_id=al.last_receive_id, last_receive_time=al.last_receive_time,
+                   tags=ARRAY(SELECT DISTINCT UNNEST(alerts.tags || al.tags)), attributes=alerts.attributes || al.attributes,
+                   duplicate_count=alerts.duplicate_count + 1, update_time=COALESCE(al.update_time, alerts.update_time),
+                   history=CASE WHEN al.history IS NULL THEN alerts.history ELSE (al.history || alerts.history)[1:{current_app.config['HISTORY_LIMIT']}] END
+            FROM (VALUES
+                {",".join(alerts_values)}
+                ) as al(
+                    environment, resource, event, severity,
+                    status, service, value, text,
+                    timeout, raw_data, last_receive_id, last_receive_time,
+                    tags, attributes, update_time, history, customer
+                )
+             WHERE alerts.environment=al.environment
+               AND alerts.resource=al.resource
+               AND alerts.event=al.event
+               AND alerts.severity=al.severity
+         RETURNING alerts.*
+        """
+        return self._updateall(update, objs, returning=True)
+
+    def create_multiple_alerts(self, alerts):
+        alerts_insert = ','.join([
+            f"""
+                (
+                    %(id{i})s, %(resource{i})s, %(event{i})s, %(environment{i})s, %(severity{i})s, %(correlate{i})s, %(status{i})s,
+                    %(service{i})s, %(group{i})s, %(value{i})s, %(text{i})s, %(tags{i})s, %(attributes{i})s, %(origin{i})s,
+                    %(event_type{i})s, %(create_time{i})s, %(timeout{i})s, %(raw_data{i})s, %(customer{i})s, %(duplicate_count{i})s,
+                    %(repeat{i})s, %(previous_severity{i})s, %(trend_indication{i})s, %(receive_time{i})s, %(last_receive_id{i})s,
+                    %(last_receive_time{i})s, %(update_time{i})s, %(history{i})s::history[]
+                )
+            """ for i in range(len(alerts))])
+        objs = {}
+        for i, alert in enumerate(alerts):
+            objs.update({f'{key}{i}': value for key, value in vars(alert).items()})
+
+        insert = f"""
+            INSERT INTO alerts (id, resource, event, environment, severity, correlate, status, service, "group",
+                value, text, tags, attributes, origin, type, create_time, timeout, raw_data, customer,
+                duplicate_count, repeat, previous_severity, trend_indication, receive_time, last_receive_id,
+                last_receive_time, update_time, history)
+            VALUES {alerts_insert}
+            RETURNING *
+        """
+        return self._insert_all(insert, objs)
+
     def create_alert(self, alert):
         insert = """
             INSERT INTO alerts (id, resource, event, environment, severity, correlate, status, service, "group",
@@ -2565,6 +2679,16 @@ class Backend(Database):
         cursor.execute(query, vars)
         self.get_db().commit()
         return cursor.fetchone()
+
+    def _insert_all(self, query, vars):
+        """
+        Insert, with return.
+        """
+        cursor = self.get_db().cursor()
+        self._log(cursor, query, vars)
+        cursor.execute(query, vars)
+        self.get_db().commit()
+        return cursor.fetchall()
 
     def _fetchone(self, query, vars):
         """

--- a/alerta/database/backends/postgres/utils.py
+++ b/alerta/database/backends/postgres/utils.py
@@ -264,6 +264,12 @@ class Alerts(QueryBuilder):
     }
 
     @staticmethod
+    def from_IDs(IDs, customers):
+        query = ['id = ANY(%(IDs)s)', 'AND (customer IS NULL or customer = ANY(%(customers)s))']
+        qvars = {'IDs': IDs, 'customers': customers}
+        return Query(where='\n'.join(query), vars=qvars, sort='', group='')
+
+    @staticmethod
     def from_params(params: MultiDict, customers=None, query_time=None):
 
         # ?q=

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -119,7 +119,16 @@ class Database(Base):
     def dedup_alert(self, alert, history):
         raise NotImplementedError
 
+    def dedup_multiple_alerts(self, alerts):
+        raise NotImplementedError
+
     def correlate_alert(self, alert, history):
+        raise NotImplementedError
+
+    def correlate_multiple_alerts(self, alerts):
+        raise NotImplementedError
+
+    def create_multiple_alerts(self, alerts):
         raise NotImplementedError
 
     def create_alert(self, alert):

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -140,6 +140,9 @@ class Database(Base):
     def set_alert(self, id, severity, status, tags, attributes, timeout, previous_severity, update_time, history=None):
         raise NotImplementedError
 
+    def set_alerts(self, alerts):
+        raise NotImplementedError
+
     def get_alert(self, id, customers=None):
         raise NotImplementedError
 
@@ -186,6 +189,9 @@ class Database(Base):
         raise NotImplementedError
 
     def get_alert_history(self, alert, page=None, page_size=None):
+        raise NotImplementedError
+
+    def get_alerts_history(self, alerts, page=None, page_size=None):
         raise NotImplementedError
 
     def get_history(self, query=None, page=None, page_size=None):

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -263,6 +263,38 @@ class Alert:
     def get_status_and_value(self):
         return [(h.status, h.value) for h in self.get_alert_history(self, page=1, page_size=10) if h.status]
 
+    @staticmethod
+    def _get_hist_infos(alerts, action=None):
+        histo = Alert.get_alerts_history(alerts)
+        statuses = {}
+        if action == ChangeType.unack:
+            find = ChangeType.ack
+        elif action == ChangeType.unshelve:
+            find = ChangeType.shelve
+        else:
+            find = None
+
+        for a in histo:
+            h_loop = a['history']
+            if not h_loop:
+                statuses[a['id']] = [None, None, None, None]
+                continue
+
+            current_status = h_loop[0].status
+            current_value = h_loop[0].value
+
+            if len(h_loop) == 1:
+                statuses[a['id']] = [current_status, current_value, None, None]
+                continue
+
+            if find:
+                for h, h_next in zip(h_loop, h_loop[1:]):
+                    if h.change_type == find:
+                        statuses[a['id']] = [current_status, current_value, h_next.status, h_next.timeout]
+                        continue
+            statuses[a['id']] = [current_status, current_value, h_loop[1].status, h_loop[1].timeout]
+        return statuses
+
     def _get_hist_info(self, action=None):
         h_loop = self.get_alert_history(alert=self)
         if not h_loop:
@@ -507,6 +539,15 @@ class Alert:
     @staticmethod
     def get_alert_history(alert, page=1, page_size=100):
         return [RichHistory.from_db(hist) for hist in db.get_alert_history(alert, page, page_size)]
+
+    @staticmethod
+    def get_alerts_history(alerts, page=1, page_size=100):
+        res = db.get_alerts_history(alerts, page, page_size)
+        try:
+            hist = [{'id': a['id'], 'history': [RichHistory.from_db(hist) for hist in a['history']]} for a in res]
+            return hist
+        except Exception as e:
+            print(e)
 
     # list alert history
     @staticmethod
@@ -797,6 +838,63 @@ class Alert:
             update_time=now,
             history=history)
         )
+
+    @staticmethod
+    def from_action_multiple(alerts, action, text='', timeout=None):
+        now = datetime.utcnow()
+        statuses = Alert._get_hist_infos(alerts, action)
+        updates = []
+        for a in alerts:
+            status, _, previous_status, previous_timeout = statuses[a.id]
+
+            if action in [ChangeType.unack, ChangeType.unshelve, ChangeType.timeout]:
+                timeout = timeout or previous_timeout
+
+            if action in [ChangeType.ack, ChangeType.unack]:
+                timeout = timeout or current_app.config['ACK_TIMEOUT']
+            elif action in [ChangeType.shelve, ChangeType.unshelve]:
+                timeout = timeout or current_app.config['SHELVE_TIMEOUT']
+            else:
+                timeout = timeout or a.timeout or current_app.config['ALERT_TIMEOUT']
+
+            new_severity, new_status = alarm_model.transition(
+                alert=a,
+                current_status=status,
+                previous_status=previous_status,
+                action=action
+            )
+
+            r = status_change_hook.send(a, status=new_status, text=text)
+            _, (_, new_status, text) = r[0]
+
+            try:
+                change_type = ChangeType(action)
+            except ValueError:
+                change_type = ChangeType.action
+
+            updates.append({
+                'id': a.id,
+                'severity': new_severity,
+                'status': new_status,
+                'tags': a.tags,
+                'attributes': a.attributes,
+                'timeout': a.timeout,
+                'previous_severity': a.severity if new_severity != a.severity else a.previous_severity,
+                'update_time': now,
+                'history': [History(
+                    id=a.id,
+                    event=a.event,
+                    severity=new_severity,
+                    status=new_status,
+                    value=a.value,
+                    text=text,
+                    change_type=change_type,
+                    update_time=now,
+                    user=g.login,
+                    timeout=timeout
+                )],
+            })
+        return [Alert.from_db(alert) for alert in db.set_alerts(updates)]
 
     def from_action(self, action: str, text: str = '', timeout: int = None) -> 'Alert':
         now = datetime.utcnow()

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -28,6 +28,81 @@ def assign_customer(wanted: str = None, permission: str = Scope.admin_alerts) ->
     return None
 
 
+def process_multiple_alert(alerts: 'list[Alert]') -> Alert:
+    new: 'list[Alert]' = []
+    correlates: 'list[dict[str, Alert]]' = []
+    duplicates:'list[dict[str, Alert]]' = []
+
+    for alert in alerts:
+
+        wanted_plugins, wanted_config = plugins.routing(alert)
+
+        skip_plugins = False
+        for plugin in wanted_plugins:
+            if alert.is_suppressed:
+                skip_plugins = True
+                break
+            try:
+                alert = plugin.pre_receive(alert, config=wanted_config)
+            except TypeError:
+                alert = plugin.pre_receive(alert)  # for backward compatibility
+            except (RejectException, HeartbeatReceived, BlackoutPeriod, RateLimit, ForwardingLoop, AlertaException):
+                raise
+            except Exception as e:
+                if current_app.config['PLUGINS_RAISE_ON_ERROR']:
+                    raise RuntimeError(f"Error while running pre-receive plugin '{plugin.name}': {str(e)}")
+                else:
+                    logging.error(f"Error while running pre-receive plugin '{plugin.name}': {str(e)}")
+            if not alert:
+                raise SyntaxError(f"Plugin '{plugin.name}' pre-receive hook did not return modified alert")
+
+        try:
+            is_duplicate = alert.is_duplicate()
+            if is_duplicate:
+                duplicates.append({'alert': alert, 'duplicate': is_duplicate})
+            else:
+                is_correlated = alert.is_correlated()
+                if is_correlated:
+                    correlates.append({'alert': alert, 'correlate': is_correlated})
+                else:
+                    new.append(alert)
+        except Exception as e:
+            raise ApiError(str(e))
+
+    alerts = []
+
+    for alert in [*Alert.update_multiple(correlates), *Alert.dedup_multiple_alerts(duplicates), *Alert.create_multiple_alerts(new)]:
+
+        wanted_plugins, wanted_config = plugins.routing(alert)
+
+        alert_was_updated: bool = False
+        for plugin in wanted_plugins:
+            if skip_plugins:
+                break
+            try:
+                updated = plugin.post_receive(alert, config=wanted_config)
+            except TypeError:
+                updated = plugin.post_receive(alert)  # for backward compatibility
+            except AlertaException:
+                raise
+            except Exception as e:
+                if current_app.config['PLUGINS_RAISE_ON_ERROR']:
+                    raise ApiError(f"Error while running post-receive plugin '{plugin.name}': {str(e)}")
+                else:
+                    logging.error(f"Error while running post-receive plugin '{plugin.name}': {str(e)}")
+            if updated:
+                alert = updated
+                alert_was_updated = True
+
+        if alert_was_updated:
+            alert.update_tags(alert.tags)
+            alert.attributes = alert.update_attributes(alert.attributes)
+
+        alerts.append(alert)
+
+    return alerts
+
+
 def process_alert(alert: Alert) -> Alert:
 
     wanted_plugins, wanted_config = plugins.routing(alert)

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -208,6 +208,49 @@ def process_action(alert: Alert, action: str, text: str, timeout: int = None, po
     return alert, action, text, timeout
 
 
+def process_multiple_action(alerts: list[Alert], action: str, text: str, timeout: int = None, post_action: bool = False) -> Tuple[list[Alert], str, str, Optional[int]]:
+    proccessed = []
+    for alert in alerts:
+        wanted_plugins, wanted_config = plugins.routing(alert)
+
+        updated = None
+        alert_was_updated = False
+        for plugin in wanted_plugins:
+            if alert.is_suppressed:
+                break
+            try:
+                if post_action:
+                    updated = plugin.post_action(alert, action, text, timeout=timeout, config=wanted_config)
+                else:
+                    updated = plugin.take_action(alert, action, text, timeout=timeout, config=wanted_config)
+            except NotImplementedError:
+                pass  # plugin does not support take_action() method or post_action() method
+            except (RejectException, ForwardingLoop, InvalidAction, AlertaException):
+                raise
+            except Exception as e:
+                if current_app.config['PLUGINS_RAISE_ON_ERROR']:
+                    raise ApiError(f"Error while running action plugin '{plugin.name}': {str(e)}")
+                else:
+                    logging.error(f"Error while running action plugin '{plugin.name}': {str(e)}")
+
+            if isinstance(updated, Alert):
+                updated = updated, action, text, timeout
+            if isinstance(updated, tuple):
+                if len(updated) == 4:
+                    alert, action, text, timeout = updated
+                elif len(updated) == 3:
+                    alert, action, text = updated
+            if updated:
+                alert_was_updated = True
+
+        if alert_was_updated:
+            alert.update_tags(alert.tags)
+            alert.attributes = alert.update_attributes(alert.attributes)
+        proccessed.append(alert)
+
+    return proccessed, action, text, timeout
+
+
 def process_note(alert: Alert, text: str) -> Tuple[Alert, str]:
 
     wanted_plugins, wanted_config = plugins.routing(alert)

--- a/alerta/utils/config.py
+++ b/alerta/utils/config.py
@@ -123,6 +123,8 @@ class Config:
 
         config['HIDDEN_PAGES'] = get_config('HIDDEN_PAGES', default=[], type=list, config=config)
 
+        config['BULK_SIZE'] = get_config('BULK_SIZE', default=50, type=int, config=config)
+
         # Runtime config check
         if config['CUSTOMER_VIEWS'] and not config['AUTH_REQUIRED']:
             raise RuntimeError('Must enable authentication to use customer views')

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -393,6 +393,18 @@ def delete_alert(alert_id):
         raise ApiError('failed to delete alert', 500)
 
 
+@api.route('/alerts', methods=['OPTIONS', 'DELETE'])
+@cross_origin()
+@permission(Scope.write_alerts)
+@timer(delete_timer)
+@jsonp
+def delete_alerts():
+    query = qb.alerts.from_params(request.args)
+    deleted = Alert.delete_find_all(query)
+
+    return jsonify(status='ok', deleted=deleted, count=len(deleted))
+
+
 @api.route('/alerts', methods=['OPTIONS', 'GET'])
 @cross_origin()
 @permission(Scope.read_alerts)

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -17,8 +17,9 @@ from alerta.models.metrics import Timer, timer
 from alerta.models.note import Note
 from alerta.models.switch import Switch
 from alerta.utils.api import (assign_customer, process_action, process_alert,
-                              process_delete, process_multiple_alert,
-                              process_note, process_status)
+                              process_delete, process_multiple_action,
+                              process_multiple_alert, process_note,
+                              process_status)
 from alerta.utils.audit import write_audit_trail
 from alerta.utils.paging import Page
 from alerta.utils.response import absolute_url, jsonp
@@ -221,6 +222,57 @@ def action_alert(alert_id):
                            customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
+        return jsonify(status='ok')
+    else:
+        raise ApiError('failed to action alert', 500)
+
+
+# action alert
+@api.route('/alerts/action', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission(Scope.write_alerts)
+@timer(status_timer)
+@jsonp
+def action_alerts():
+    alert_ids = request.json.get('alerts')
+    action = request.json.get('action', None)
+    text = request.json.get('text', f'{action} operator action')
+    timeout = request.json.get('timeout', None)
+
+    if not alert_ids:
+        raise ApiError("must supply 'alert IDs' as json data", 400)
+    if not action:
+        raise ApiError("must supply 'action' as json data", 400)
+
+    customers = g.get('customers', None)
+    query = qb.alerts.from_IDs(alert_ids, customers)
+    alerts = Alert.find_all(query, page_size=len(alert_ids))
+
+    def post(alerts: list[Alert], action, text, timeout):
+        Alert.from_action_multiple(alerts, action, text, timeout)
+        return process_multiple_action(alerts, action, text, timeout, post_action=True)
+
+    try:
+        # pre action
+        alerts, action, text, timeout = process_multiple_action(alerts, action, text, timeout)
+        alerts, action, text, timeout = post(alerts, action, text, timeout)
+    except RejectException as e:
+        current_app.logger.warning(e)
+        raise ApiError(str(e), 400)
+    except InvalidAction as e:
+        current_app.logger.warning(e)
+        raise ApiError(str(e), 409)
+    except ForwardingLoop as e:
+        current_app.logger.warning(e)
+        return jsonify(status='ok', message=str(e)), 202
+    except AlertaException as e:
+        current_app.logger.warning(e)
+        raise ApiError(e.message, code=e.code, errors=e.errors)
+    except Exception as e:
+        current_app.logger.warning(e)
+        raise ApiError(str(e), 500)
+
+    if alerts:
         return jsonify(status='ok')
     else:
         raise ApiError('failed to action alert', 500)

--- a/alerta/views/config.py
+++ b/alerta/views/config.py
@@ -72,4 +72,5 @@ def config():
         'environments': current_app.config['ALLOWED_ENVIRONMENTS'],
         'clipboard_template': current_app.config['CLIPBOARD_TEMPLATE'],
         'hidden_pages': current_app.config['HIDDEN_PAGES'],
+        'bulk_size': current_app.config['BULK_SIZE']
     })


### PR DESCRIPTION
**Desctription**
Add API bulk endpoints for alerts, alert actions, and alert deletion. 

**Changes**
- add endpoint for bulk posting new/updating multiple alerts
- add endpoint for doing an action for multiple alerts
- add endpoint for deleting multiple alerts
- add faster return from notification rules plugin when there are no matching rules