### PR TITLE
feat: remove unused functions of alarm model

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1018,6 +1018,13 @@ class Backend(Database):
         """
         return self._fetchone(select, query.vars).count
 
+    def is_shelved(self, alert):
+        select = """
+            select true from alerts where status='shelved' AND resource=%(resource)s AND event=%(event)s AND environment=%(environment)s
+        """
+        test = self._fetchone(select, vars(alert))
+        return test is not None
+
     def is_blackout_period(self, alert):
         select = """
             SELECT *

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -146,6 +146,9 @@ class Database(Base):
     def get_alert(self, id, customers=None):
         raise NotImplementedError
 
+    def is_shelved(self, alert):
+        raise NotImplementedError
+
     # STATUS, TAGS, ATTRIBUTES
 
     def set_status(self, id, status, timeout, update_time, history=None):

--- a/alerta/models/alarms/alerta_isa_18_2.py
+++ b/alerta/models/alarms/alerta_isa_18_2.py
@@ -56,17 +56,12 @@ COLOR_MAP = {
     'text': 'black'
 }
 
-F_DSUPR = 'DSUPR'
-G_OOSRV = 'OOSRV'
-
 STATUS_MAP = {
     Status.Closed: 'A',
     Status.Open: 'B',
     Status.Ack: 'C',
     Status.Unack: 'D',
     Status.Shelved: 'E',
-    F_DSUPR: 'F',
-    G_OOSRV: 'G'
 }
 
 MORE_SEVERE = 'moreSevere'
@@ -174,22 +169,8 @@ class StateMachine(AlarmModel):
             if current_severity == StateMachine.DEFAULT_NORMAL_SEVERITY:
                 return next_state('Open -> Unack', current_severity, Status.Unack)
 
-        # Return from Suppressed-by-design (F) -> Normal (A) or Unack (B)
-        if state == F_DSUPR:
-            if current_severity == StateMachine.DEFAULT_NORMAL_SEVERITY:
-                return next_state('Return from Suppressed-by-design, Suppressed-by-design (G) -> Normal (A)', current_severity, Status.Closed)
-            else:
-                return next_state('Return from Suppressed-by-design, Suppressed-by-design (G) -> Unack (B)', current_severity, Status.Open)
-
-        # Return from Out-of-service (G) -> Normal (A) or Unack (B)
-        if state == G_OOSRV:
-            if current_severity == StateMachine.DEFAULT_NORMAL_SEVERITY:
-                return next_state('Return from Out-of-service, Out-of-service (G) -> Normal (A)', current_severity, Status.Closed)
-            else:
-                return next_state('Return from Out-of-service, Out-of-service (G) -> Unack (B)', current_severity, Status.Open)
-
         return next_state('NOOP', current_severity, state)
 
     @staticmethod
     def is_suppressed(alert):
-        return alert.status in [F_DSUPR, G_OOSRV]
+        return alert.status == Status.Shelved

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -454,6 +454,10 @@ class Alert:
         return db.is_blackout_period(self)
 
     @property
+    def is_shelved(self) -> bool:
+        return db.is_shelved(self)
+
+    @property
     def is_suppressed(self) -> bool:
         """Is the alert status 'blackout'?"""
         return alarm_model.is_suppressed(self)

--- a/alerta/plugins/notification_rule.py
+++ b/alerta/plugins/notification_rule.py
@@ -345,7 +345,7 @@ class NotificationRulesHandler(PluginBase):
         return alert
 
     def post_receive(self, alert: 'Alert', **kwargs):
-        if not alert:
+        if not alert or alert.is_shelved:
             return
         NotificationDelay.delete_alert(alert.id)
         config = kwargs.get('config')


### PR DESCRIPTION
**Description**
remove unused functions of the alarm model

**Changes**
- remove DSUPR(suppressed by design) and OOSRV(out of service) statuses from alerta-isa-18-2
- add database query for shelved status in notification rule plugin and ignore all shelved alarms (replaces OOSRV isshelved function)