### PR TITLE
feat: change timeout to shelved/acked timeouts

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -327,7 +327,7 @@ class Backend(Database):
         update = f"""
             UPDATE alerts
                SET event=al.event, severity=al.severity, status=al.status, service=al.service, value=al.value, text=al.text,
-                   create_time=al.create_time, timeout=al.timeout, raw_data=al.raw_data, previous_severity=al.previous_severity,
+                   create_time=al.create_time, timeout=CASE WHEN al.status != ALL (ARRAY['ack', 'shelved']) THEN al.timeout ELSE alerts.timeout END, raw_data=al.raw_data, previous_severity=al.previous_severity,
                    receive_time=al.receive_time, last_receive_id=al.last_receive_id, last_receive_time=al.last_receive_time,
                    tags=ARRAY(SELECT DISTINCT UNNEST(alerts.tags || al.tags)), attributes=alerts.attributes || al.attributes,
                    duplicate_count=al.duplicate_count, update_time=COALESCE(al.update_time, alerts.update_time),
@@ -361,7 +361,7 @@ class Backend(Database):
                 (
                     %(environment{i})s, %(resource{i})s, %(event{i})s, %(severity{i})s,
                     %(status{i})s,%(service{i})s,%(value{i})s, %(text{i})s,
-                    %(timeout{i})s, %(raw_data{i})s, %(last_receive_id{i})s, (%(last_receive_time{i})s)::timestamp without time zone,
+                    %(raw_data{i})s, %(last_receive_id{i})s, (%(last_receive_time{i})s)::timestamp without time zone,
                     %(tags{i})s, (%(attributes{i})s)::jsonb, (%(update_time{i})s)::timestamp without time zone,
                     (%(history{i})s)::history, %(customer{i})s
                 )
@@ -371,7 +371,7 @@ class Backend(Database):
         update = f"""
             UPDATE alerts
                SET status=al.status, service=al.service, value=al.value, text=al.text,
-                   timeout=al.timeout, raw_data=al.raw_data,
+                   raw_data=al.raw_data,
                    last_receive_id=al.last_receive_id, last_receive_time=al.last_receive_time,
                    tags=ARRAY(SELECT DISTINCT UNNEST(alerts.tags || al.tags)), attributes=alerts.attributes || al.attributes,
                    duplicate_count=alerts.duplicate_count + 1, update_time=COALESCE(al.update_time, alerts.update_time),
@@ -381,7 +381,7 @@ class Backend(Database):
                 ) as al(
                     environment, resource, event, severity,
                     status, service, value, text,
-                    timeout, raw_data, last_receive_id, last_receive_time,
+                    raw_data, last_receive_id, last_receive_time,
                     tags, attributes, update_time, history, customer
                 )
              WHERE alerts.environment=al.environment
@@ -2641,62 +2641,28 @@ class Backend(Database):
 
     # HOUSEKEEPING
 
-    def get_expired(self, expired_threshold, info_threshold):
-        # delete 'closed' or 'expired' alerts older than "expired_threshold" seconds
-        # and 'informational' alerts older than "info_threshold" seconds
-
-        if expired_threshold:
-            delete = """
-                DELETE FROM alerts
-                 WHERE (status IN ('closed', 'expired')
-                        AND last_receive_time < (NOW() at time zone 'utc' - INTERVAL '%(expired_threshold)s seconds'))
-            """
-            self._deleteall(delete, {'expired_threshold': expired_threshold})
-
-        if info_threshold:
-            delete = """
-                DELETE FROM alerts
-                 WHERE (severity=%(inform_severity)s
-                        AND last_receive_time < (NOW() at time zone 'utc' - INTERVAL '%(info_threshold)s seconds'))
-            """
-            self._deleteall(delete, {'inform_severity': alarm_model.DEFAULT_INFORM_SEVERITY, 'info_threshold': info_threshold})
-
-        # get list of alerts to be newly expired
-        select = """
-            SELECT *
-              FROM alerts
-             WHERE status NOT IN ('expired') AND COALESCE(timeout, {timeout})!=0
-               AND (last_receive_time + INTERVAL '1 second' * timeout) < NOW() at time zone 'utc'
-        """.format(timeout=current_app.config['ALERT_TIMEOUT'])
-
-        return self._fetchall(select, {})
-
     def get_unshelve(self):
         # get list of alerts to be unshelved
-        select = """
-            SELECT DISTINCT ON (a.id) a.*
-              FROM alerts a, UNNEST(history) h
-             WHERE a.status='shelved'
-               AND h.type='shelve'
-               AND h.status='shelved'
-               AND COALESCE(h.timeout, {timeout})!=0
-               AND (a.update_time + INTERVAL '1 second' * h.timeout) < NOW() at time zone 'utc'
-          ORDER BY a.id, a.update_time DESC
-        """.format(timeout=current_app.config['SHELVE_TIMEOUT'])
+        select = f"""
+            SELECT *
+                FROM alerts
+                WHERE status='shelved'
+                AND COALESCE(timeout, {current_app.config['SHELVE_TIMEOUT']})!=0
+                AND (update_time + INTERVAL '1 second' * timeout) < NOW() at time zone 'utc'
+            ORDER BY update_time DESC
+        """
         return self._fetchall(select, {})
 
     def get_unack(self):
         # get list of alerts to be unack'ed
-        select = """
-            SELECT DISTINCT ON (a.id) a.*
-              FROM alerts a, UNNEST(history) h
-             WHERE a.status='ack'
-               AND h.type='ack'
-               AND h.status='ack'
-               AND COALESCE(h.timeout, {timeout})!=0
-               AND (a.update_time + INTERVAL '1 second' * h.timeout) < NOW() at time zone 'utc'
-          ORDER BY a.id, a.update_time DESC
-        """.format(timeout=current_app.config['ACK_TIMEOUT'])
+        select = f"""
+            SELECT *
+              FROM alerts
+             WHERE status='ack'
+               AND COALESCE(timeout, {current_app.config['ACK_TIMEOUT']})!=0
+               AND (update_time + INTERVAL '1 second' * timeout) < NOW() at time zone 'utc'
+          ORDER BY id, update_time DESC
+        """
         return self._fetchall(select, {})
 
     # SQL HELPERS

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -659,9 +659,6 @@ class Database(Base):
 
     # HOUSEKEEPING
 
-    def get_expired(self, expired_threshold, info_threshold):
-        raise NotImplementedError
-
     def get_unshelve(self):
         raise NotImplementedError
 

--- a/alerta/management/views.py
+++ b/alerta/management/views.py
@@ -158,41 +158,12 @@ def health_check():
 @cross_origin()
 @permission(Scope.admin_management)
 def housekeeping():
-    expired_threshold_hrs = request.args.get('expired', type=int)
-    info_threshold_hrs = request.args.get('info', type=int)
 
-    if expired_threshold_hrs:
-        expired_threshold = expired_threshold_hrs * 60 * 60  # convert hours to seconds
-    else:
-        expired_threshold = current_app.config['DELETE_EXPIRED_AFTER']  # seconds
-
-    if info_threshold_hrs:
-        info_threshold = info_threshold_hrs * 60 * 60  # convert hours to seconds
-    else:
-        info_threshold = current_app.config['DELETE_INFO_AFTER']  # seconds
-
-    has_expired, shelve_timeout, ack_timeout = Alert.housekeeping(expired_threshold, info_threshold)
+    shelve_timeout, ack_timeout = Alert.housekeeping()
 
     errors = []
-    for alert in has_expired:
-        try:
-            # pre actioon
-            alert, _, text, timeout = process_action(alert, action='expired', text='', timeout=None)
-            # update status
-            alert = alert.from_expired(text, timeout)
-            # post action
-            alert, _, text, timeout = process_action(alert, action='expired', text=text, timeout=timeout, post_action=True)
-        except RejectException as e:
-            write_audit_trail.send(current_app._get_current_object(), event='alert-expire-rejected', message=alert.text,
-                                   user=g.login, customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert',
-                                   request=request)
-            errors.append(str(e))
-            continue
-        except Exception as e:
-            raise ApiError(str(e), 500)
 
-        write_audit_trail.send(current_app._get_current_object(), event='alert-expired', message=text, user=g.login,
-                               customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    # alerts, _, text, timeout = process_multiple_action([*shelve_timeout, *ack_timeout], 'timeout', '', None)
 
     for alert in shelve_timeout + ack_timeout:
         try:
@@ -219,10 +190,9 @@ def housekeeping():
     else:
         return jsonify(
             status='ok',
-            expired=[a.id for a in has_expired],
             unshelve=[a.id for a in shelve_timeout],
             unack=[a.id for a in ack_timeout],
-            count=len(has_expired) + len(shelve_timeout) + len(ack_timeout)
+            count=len(shelve_timeout) + len(ack_timeout)
         )
 
 

--- a/alerta/models/alarms/alerta_isa_18_2.py
+++ b/alerta/models/alarms/alerta_isa_18_2.py
@@ -72,6 +72,7 @@ ACTION_ACK = 'ack'
 ACTION_UNACK = 'unack'
 ACTION_SHELVE = 'shelve'
 ACTION_UNSHELVE = 'unshelve'
+ACTION_TIMOUT = 'timeout'
 ACTION_OPEN = 'open'
 
 
@@ -126,8 +127,7 @@ class StateMachine(AlarmModel):
 
         if action == ACTION_SHELVE:
             return next_state('Operator Shelve, Any (*) -> Shelve (E)', current_severity, Status.Shelved)
-
-        if action == ACTION_UNSHELVE:
+        if action == ACTION_UNSHELVE or (state == Status.Shelved and action == ACTION_TIMOUT):
             if current_severity == StateMachine.DEFAULT_NORMAL_SEVERITY:
                 return next_state('Operator Unshelve, Shelve (E) -> Normal (A)', current_severity, Status.Closed)
             else:
@@ -147,7 +147,7 @@ class StateMachine(AlarmModel):
             if state == Status.Unack:
                 return next_state(' Operator Ack, RTN Unack (D) -> Normal (A)', current_severity, Status.Closed)
 
-        if action == ACTION_UNACK:
+        if action == ACTION_UNACK or (state == Status.Ack and action == ACTION_TIMOUT):
             if state == Status.Ack:
                 return next_state('Operator Unack, Ack (C) -> Unack (B)', current_severity, Status.Open)
 

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -41,7 +41,7 @@ class Alert:
             if kwargs['status'] not in alarm_model.Status.keys():
                 raise ValueError(f'Status must be one of: {", ".join(alarm_model.Status.keys())}')
 
-        timeout = kwargs.get('timeout') if kwargs.get('timeout') is not None else current_app.config['ALERT_TIMEOUT']
+        timeout = kwargs.get('timeout') or 0
         try:
             timeout = int(timeout)  # type: ignore
         except ValueError:
@@ -87,8 +87,6 @@ class Alert:
             raise ValueError('tags must be a list')
         if not isinstance(json.get('attributes', {}), dict):
             raise ValueError('attributes must be a JSON object')
-        if not isinstance(json.get('timeout') if json.get('timeout', None) is not None else 0, int):
-            raise ValueError('timeout must be an integer')
         if json.get('customer', None) == '':
             raise ValueError('customer must not be an empty string')
 
@@ -106,7 +104,6 @@ class Alert:
             attributes=json.get('attributes', dict()),
             origin=json.get('origin', None),
             create_time=DateTime.parse(json['createTime']) if 'createTime' in json else None,
-            timeout=json.get('timeout', None),
             raw_data=json.get('rawData', None),
             customer=json.get('customer', None)
         )
@@ -443,7 +440,7 @@ class Alert:
     def set_status(self, status: str, text: str = '', timeout: int = None) -> 'Alert':
         now = datetime.now(UTC)
 
-        timeout = timeout or current_app.config['ALERT_TIMEOUT']
+        timeout = timeout or 0
         history = History(
             id=self.id,
             event=self.event,
@@ -772,9 +769,8 @@ class Alert:
         return Note.delete_by_id(note_id)
 
     @staticmethod
-    def housekeeping(expired_threshold: int, info_threshold: int) -> Tuple[List['Alert'], List['Alert'], List['Alert']]:
+    def housekeeping() -> Tuple[List['Alert'], List['Alert'], List['Alert']]:
         return (
-            [Alert.from_db(alert) for alert in db.get_expired(expired_threshold, info_threshold)],
             [Alert.from_db(alert) for alert in db.get_unshelve()],
             [Alert.from_db(alert) for alert in db.get_unack()]
         )
@@ -782,7 +778,7 @@ class Alert:
     def from_status(self, status: str, text: str = '', timeout: int = None) -> 'Alert':
         now = datetime.now(UTC)
 
-        self.timeout = timeout or current_app.config['ALERT_TIMEOUT']
+        self.timeout = timeout or 0
         history = [History(
             id=self.id,
             event=self.event,
@@ -818,12 +814,12 @@ class Alert:
             if action in [ChangeType.unack, ChangeType.unshelve, ChangeType.timeout]:
                 timeout = timeout or previous_timeout
 
-            if action in [ChangeType.ack, ChangeType.unack]:
+            if action in [ChangeType.ack]:
                 timeout = timeout or current_app.config['ACK_TIMEOUT']
-            elif action in [ChangeType.shelve, ChangeType.unshelve]:
+            elif action in [ChangeType.shelve]:
                 timeout = timeout or current_app.config['SHELVE_TIMEOUT']
             else:
-                timeout = timeout or a.timeout or current_app.config['ALERT_TIMEOUT']
+                timeout = timeout or 0
 
             new_severity, new_status = alarm_model.transition(
                 alert=a,
@@ -846,7 +842,7 @@ class Alert:
                 'status': new_status,
                 'tags': a.tags,
                 'attributes': a.attributes,
-                'timeout': a.timeout,
+                'timeout': int(timeout),
                 'previous_severity': a.severity if new_severity != a.severity else a.previous_severity,
                 'update_time': now,
                 'history': [History(
@@ -872,12 +868,12 @@ class Alert:
         if action in [ChangeType.unack, ChangeType.unshelve, ChangeType.timeout]:
             timeout = timeout or previous_timeout
 
-        if action in [ChangeType.ack, ChangeType.unack]:
+        if action in [ChangeType.ack]:
             timeout = timeout or current_app.config['ACK_TIMEOUT']
-        elif action in [ChangeType.shelve, ChangeType.unshelve]:
+        elif action in [ChangeType.shelve]:
             timeout = timeout or current_app.config['SHELVE_TIMEOUT']
         else:
-            timeout = timeout or self.timeout or current_app.config['ALERT_TIMEOUT']
+            timeout = timeout or 0
 
         new_severity, new_status = alarm_model.transition(
             alert=self,
@@ -913,14 +909,11 @@ class Alert:
             status=new_status,
             tags=self.tags,
             attributes=self.attributes,
-            timeout=self.timeout,
+            timeout=timeout,
             previous_severity=self.severity if new_severity != self.severity else self.previous_severity,
             update_time=now,
             history=history)
         )
-
-    def from_expired(self, text: str = '', timeout: int = None):
-        return self.from_action(action='expired', text=text, timeout=timeout)
 
     def from_timeout(self, text: str = '', timeout: int = None):
         return self.from_action(action='timeout', text=text, timeout=timeout)

--- a/alerta/plugins/heartbeat.py
+++ b/alerta/plugins/heartbeat.py
@@ -27,7 +27,7 @@ class HeartbeatReceiver(PluginBase):
                     'severity': alert.severity,
                     'service': alert.service,
                 },
-                timeout=alert.timeout,
+                timeout=alert.timeout or kwargs['config']['HEARTBEAT_TIMEOUT'],
                 customer=alert.customer
             )
             r = hb.create()

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -193,16 +193,10 @@ DEFAULT_PREVIOUS_SEVERITY = None
 COLOR_MAP = {}  # type: Dict[str, Any]
 
 # Timeout settings
-DEFAULT_TIMEOUT = 86400  # seconds
-ALERT_TIMEOUT = DEFAULT_TIMEOUT
-HEARTBEAT_TIMEOUT = DEFAULT_TIMEOUT
+HEARTBEAT_TIMEOUT = 86400
 HEARTBEAT_MAX_LATENCY = 2000  # ms
 ACK_TIMEOUT = 0  # auto-unack alerts after x seconds (0 seconds = do not auto-unack)
-SHELVE_TIMEOUT = 7200  # auto-unshelve alerts after x seconds (0 seconds = do not auto-unshelve)
-
-# Housekeeping settings
-DELETE_EXPIRED_AFTER = 2 * 60 * 60  # seconds (0 = do not delete)
-DELETE_INFO_AFTER = 12 * 60 * 60  # seconds (0 = do not delete)
+SHELVE_TIMEOUT = 0  # auto-unshelve alerts after x seconds (0 seconds = do not auto-unshelve)
 
 # Send verification emails to new BasicAuth users
 EMAIL_VERIFICATION = False

--- a/alerta/utils/config.py
+++ b/alerta/utils/config.py
@@ -83,19 +83,6 @@ class Config:
 
         config['GOOGLE_TRACKING_ID'] = get_config('GOOGLE_TRACKING_ID', default=None, type=str, config=config)
 
-        # housekeeping
-        config['DELETE_EXPIRED_AFTER'] = (
-            get_config('DEFAULT_EXPIRED_DELETE_HRS', default=0, type=int, config=config) * 60 * 60
-            or get_config('HK_EXPIRED_DELETE_HRS', default=0, type=int) * 60 * 60
-            or get_config('DELETE_EXPIRED_AFTER', default=None, type=int, config=config)
-        )
-
-        config['DELETE_INFO_AFTER'] = (
-            get_config('DEFAULT_INFO_DELETE_HRS', default=0, type=int, config=config) * 60 * 60
-            or get_config('HK_INFO_DELETE_HRS', default=0, type=int) * 60 * 60
-            or get_config('DELETE_INFO_AFTER', default=None, type=int, config=config)
-        )
-
         # plugins
         config['PLUGINS'] = get_config('PLUGINS', default=[], type=list, config=config)
 

--- a/alerta/views/config.py
+++ b/alerta/views/config.py
@@ -42,7 +42,6 @@ def config():
         'oidc_auth_url': current_app.config['OIDC_AUTH_URL'],
         'site_logo_url': current_app.config['SITE_LOGO_URL'],
         'timeouts': {
-            'alert': current_app.config['ALERT_TIMEOUT'],
             'heartbeat': current_app.config['HEARTBEAT_TIMEOUT'],
             'ack': current_app.config['ACK_TIMEOUT'],
             'shelve': current_app.config['SHELVE_TIMEOUT']

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -12,7 +12,6 @@ class ActionsTestCase(unittest.TestCase):
         test_config = {
             'TESTING': True,
             'AUTH_REQUIRED': False,
-            'ALERT_TIMEOUT': 120,
             'HISTORY_LIMIT': 5
         }
         self.app = create_app(test_config)

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -12,7 +12,6 @@ class AggregationsTestCase(unittest.TestCase):
         test_config = {
             'TESTING': True,
             'AUTH_REQUIRED': False,
-            'ALERT_TIMEOUT': 120,
             'HISTORY_LIMIT': 5
         }
         self.app = create_app(test_config)

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -16,7 +16,6 @@ class AlertsTestCase(unittest.TestCase):
         test_config = {
             'TESTING': True,
             'AUTH_REQUIRED': False,
-            'ALERT_TIMEOUT': 120,
             'HISTORY_LIMIT': 5
         }
         self.app = create_app(test_config)
@@ -727,53 +726,6 @@ class AlertsTestCase(unittest.TestCase):
         self.assertListEqual([h['value'] for h in data['alert']['history']], ['101', '102', '99', '104', '105'])
         self.assertListEqual([h['type'] for h in data['alert']['history']],
                              ['status', 'value', 'severity', 'severity', 'value'])
-
-    def test_timeout(self):
-
-        # create alert with default timeout
-        response = self.client.post('/alert', data=json.dumps(self.fatal_alert), headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['timeout'], 120)
-
-        # resend alert with different timeout
-        self.fatal_alert['timeout'] = 20
-        response = self.client.post('/alert', data=json.dumps(self.fatal_alert), headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['timeout'], 20)
-
-        # resend alert with timeout disabled (ie. 0)
-        self.fatal_alert['timeout'] = 0
-        response = self.client.post('/alert', data=json.dumps(self.fatal_alert), headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['timeout'], 0)
-
-        # send correlated with different timeout
-        response = self.client.post('/alert', data=json.dumps(self.major_alert), headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['timeout'], 40)
-
-        # send different correlated alert with different timeout
-        response = self.client.post('/alert', data=json.dumps(self.warn_alert), headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['timeout'], 50)
-
-        # send same correlated alert with different timeout
-        self.warn_alert['timeout'] = 60
-        response = self.client.post('/alert', data=json.dumps(self.warn_alert), headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['timeout'], 60)
-
-        # send ok alert with default timeout
-        response = self.client.post('/alert', data=json.dumps(self.ok_alert), headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['timeout'], 120)
 
     def test_filter_params(self):
         # create alert

--- a/tests/test_heartbeats.py
+++ b/tests/test_heartbeats.py
@@ -14,7 +14,6 @@ class HeartbeatsTestCase(unittest.TestCase):
         test_config = {
             'TESTING': True,
             'AUTH_REQUIRED': False,
-            'ALERT_TIMEOUT': 2,
             'HEARTBEAT_TIMEOUT': 4,
             'HEARTBEAT_EVENTS': ['Heartbeat', 'Watchdog'],
             'PLUGINS': ['heartbeat']
@@ -154,7 +153,7 @@ class HeartbeatsTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['resource'], hb.origin)
         self.assertEqual(data['alert']['status'], 'open')
         self.assertEqual(data['alert']['service'], ['Test'])
-        self.assertEqual(data['alert']['timeout'], 2)
+        self.assertEqual(data['alert']['timeout'], 0)
         self.assertEqual(data['alert']['duplicateCount'], 0)
         self.assertEqual(data['alert']['severity'], 'major')
         self.assertEqual(data['alert']['history'][0]['user'], None)
@@ -167,7 +166,6 @@ class HeartbeatsTestCase(unittest.TestCase):
             'environment': 'Production',
             'service': ['Svc1'],
             'origin': 'test/hb',
-            'timeout': 500
         }
 
         response = self.client.post('/alert', data=json.dumps(heartbeat_alert), headers=self.headers)
@@ -179,7 +177,7 @@ class HeartbeatsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['heartbeats'][0]['origin'], 'test/hb')
-        self.assertEqual(data['heartbeats'][0]['timeout'], 500)
+        self.assertEqual(data['heartbeats'][0]['timeout'], 4)
 
         prometheus_alert = r"""
         {

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -121,7 +121,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertDictEqual(alert.attributes, {'region': 'EU', 'site': 'london'})
         self.assertEqual(alert.origin, 'test_hooks.py')
         self.assertIsInstance(alert.create_time, datetime)
-        self.assertEqual(alert.timeout, 86400)
+        self.assertEqual(alert.timeout, 0)
         self.assertEqual(alert.raw_data, 'raw text')
         self.assertIsNone(alert.customer)
 
@@ -149,7 +149,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertDictEqual(alert.attributes, {'region': 'EU', 'site': 'london'})
         self.assertEqual(alert.origin, 'test_hooks.py')
         self.assertIsInstance(alert.create_time, datetime)
-        self.assertEqual(alert.timeout, 86400)
+        self.assertEqual(alert.timeout, 0)
         self.assertEqual(alert.raw_data, 'raw text')
         self.assertIsNone(alert.customer)
 
@@ -168,7 +168,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertEqual(alert.history[0].text, 'node is down.')
         self.assertEqual(alert.history[0].change_type, 'new')
         self.assertIsNone(alert.history[0].user)
-        self.assertEqual(alert.history[0].timeout, 86400)
+        self.assertEqual(alert.history[0].timeout, 0)
 
         return alert
 
@@ -186,7 +186,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertDictEqual(alert.attributes, {'region': 'EU', 'site': 'london'})
         self.assertEqual(alert.origin, 'test_hooks.py')
         self.assertIsInstance(alert.create_time, datetime)
-        self.assertEqual(alert.timeout, 86400)
+        self.assertEqual(alert.timeout, 0)
         self.assertEqual(alert.raw_data, 'raw text')
         self.assertIsNone(alert.customer)
 
@@ -205,7 +205,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertEqual(alert.history[0].text, 'node is down.')
         self.assertEqual(alert.history[0].change_type, 'new')
         self.assertIsNone(alert.history[0].user)
-        self.assertEqual(alert.history[0].timeout, 86400)
+        self.assertEqual(alert.history[0].timeout, 0)
 
         self.assertEqual(action, 'ack')
         self.assertEqual(text, 'ack text')
@@ -226,7 +226,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertDictEqual(alert.attributes, {'region': 'EU', 'site': 'london'})
         self.assertEqual(alert.origin, 'test_hooks.py')
         self.assertIsInstance(alert.create_time, datetime)
-        self.assertEqual(alert.timeout, 86400)
+        self.assertEqual(alert.timeout, 0)
         self.assertEqual(alert.raw_data, 'raw text')
         self.assertIsNone(alert.customer)
 
@@ -245,7 +245,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertEqual(alert.history[0].text, 'node is down.')
         self.assertEqual(alert.history[0].change_type, 'new')
         self.assertIsNone(alert.history[0].user)
-        self.assertEqual(alert.history[0].timeout, 86400)
+        self.assertEqual(alert.history[0].timeout, 0)
 
         self.assertEqual(status, 'ack')
         self.assertEqual(text, 'ack text')
@@ -266,7 +266,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertDictEqual(alert.attributes, {'region': 'EU', 'site': 'london'})
         self.assertEqual(alert.origin, 'test_hooks.py')
         self.assertIsInstance(alert.create_time, datetime)
-        self.assertEqual(alert.timeout, 86400)
+        self.assertEqual(alert.timeout, 0)
         self.assertEqual(alert.raw_data, 'raw text')
         self.assertIsNone(alert.customer)
 
@@ -295,7 +295,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertEqual(alert.history[1].text, 'node is down.')
         self.assertEqual(alert.history[1].change_type, 'new')
         self.assertIsNone(alert.history[1].user)
-        self.assertEqual(alert.history[1].timeout, 86400)
+        self.assertEqual(alert.history[1].timeout, 0)
 
         self.assertEqual(text, 'this is a note')
 
@@ -315,7 +315,7 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertDictEqual(alert.attributes, {'region': 'EU', 'site': 'london'})
         self.assertEqual(alert.origin, 'test_hooks.py')
         self.assertIsInstance(alert.create_time, datetime)
-        self.assertEqual(alert.timeout, 86400)
+        self.assertEqual(alert.timeout, 0)
         self.assertEqual(alert.raw_data, 'raw text')
         self.assertIsNone(alert.customer)
 
@@ -354,6 +354,6 @@ class Plugin1(unittest.TestCase, PluginBase):
         self.assertEqual(alert.history[2].text, 'node is down.')
         self.assertEqual(alert.history[2].change_type, 'new')
         self.assertIsNone(alert.history[2].user)
-        self.assertEqual(alert.history[2].timeout, 86400)
+        self.assertEqual(alert.history[2].timeout, 0)
 
         return True

--- a/tests/test_isa_18_2.py
+++ b/tests/test_isa_18_2.py
@@ -14,7 +14,6 @@ class Isa182TestCase(unittest.TestCase):
             'ALARM_MODEL': 'ISA_18_2',
             'AUTH_REQUIRED': False,
             'PLUGINS': [],
-            'ALERT_TIMEOUT': 120,
             'HISTORY_LIMIT': 5
         }
         self.app = create_app(test_config, environment='development')

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -4,7 +4,6 @@ import unittest
 from uuid import uuid4
 
 from alerta.app import create_app, db
-from tests.helpers.utils import mod_env
 
 
 class ManagementTestCase(unittest.TestCase):
@@ -23,12 +22,8 @@ class ManagementTestCase(unittest.TestCase):
             # 'SERVER_VERSION': 'major'
         }
 
-        with mod_env(
-            DELETE_EXPIRED_AFTER='2',
-            DELETE_INFO_AFTER='3'
-        ):
-            self.app = create_app(test_config)
-            self.client = self.app.test_client()
+        self.app = create_app(test_config)
+        self.client = self.app.test_client()
 
         self.headers = {
             'Content-type': 'application/json'
@@ -37,7 +32,7 @@ class ManagementTestCase(unittest.TestCase):
         def random_resource():
             return str(uuid4()).upper()[:8]
 
-        self.expired_alert = {
+        self.alert = {
             'event': 'node_down',
             'resource': random_resource(),
             'environment': 'Production',
@@ -46,7 +41,6 @@ class ManagementTestCase(unittest.TestCase):
             'correlate': ['node_down', 'node_marginal', 'node_up'],
             'tags': ['foo'],
             'attributes': {'foo': 'abc def', 'bar': 1234, 'baz': False},
-            'timeout': 2
         }
 
         self.shelved_alert = {
@@ -126,19 +120,6 @@ class ManagementTestCase(unittest.TestCase):
 
     def test_housekeeping(self):
 
-        # create an alert with short timeout that will expire
-        response = self.client.post('/alert', data=json.dumps(self.expired_alert), headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-
-        expired_id = data['id']
-
-        response = self.client.get('/alert/' + expired_id)
-        self.assertEqual(response.status_code, 200)
-        data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['id'], expired_id)
-        self.assertEqual(data['alert']['timeout'], 2)
-
         # create an alert and shelve it
         response = self.client.post('/alert', data=json.dumps(self.shelved_alert), headers=self.headers)
         self.assertEqual(response.status_code, 201)
@@ -154,8 +135,8 @@ class ManagementTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['id'], shelved_id)
-        self.assertEqual(data['alert']['timeout'], 20)
-        self.assertEqual(data['alert']['history'][0]['timeout'], 20)
+        self.assertEqual(data['alert']['timeout'], 3)
+        self.assertEqual(data['alert']['history'][0]['timeout'], 0)
         self.assertEqual(data['alert']['history'][1]['timeout'], 3)
 
         # create an alert and ack it
@@ -173,22 +154,15 @@ class ManagementTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['id'], acked_id)
-        self.assertEqual(data['alert']['timeout'], 86400)
+        self.assertEqual(data['alert']['timeout'], 2)
         self.assertEqual(data['alert']['history'][0]['status'], 'open')
-        self.assertEqual(data['alert']['history'][0]['timeout'], 86400)
+        self.assertEqual(data['alert']['history'][0]['timeout'], 0)
         self.assertEqual(data['alert']['history'][1]['status'], 'ack')
         self.assertEqual(data['alert']['history'][1]['timeout'], 2)
 
         # create an alert that should be unaffected
         response = self.client.post('/alert', data=json.dumps(self.ok_alert), headers=self.headers)
         self.assertEqual(response.status_code, 201)
-
-        # create an info alert that should be deleted
-        response = self.client.post('/alert', data=json.dumps(self.info_alert), headers=self.headers)
-        self.assertEqual(response.status_code, 201)
-        data = json.loads(response.data.decode('utf-8'))
-
-        info_id = data['id']
 
         # create an alert and ack it then shelve it
         response = self.client.post('/alert', data=json.dumps(self.acked_and_shelved_alert), headers=self.headers)
@@ -209,9 +183,9 @@ class ManagementTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['id'], acked_and_shelved_id)
-        self.assertEqual(data['alert']['timeout'], 240)
+        self.assertEqual(data['alert']['timeout'], 3)
         self.assertEqual(data['alert']['history'][0]['status'], 'open')
-        self.assertEqual(data['alert']['history'][0]['timeout'], 240)
+        self.assertEqual(data['alert']['history'][0]['timeout'], 0)
         self.assertEqual(data['alert']['history'][1]['status'], 'ack')
         self.assertEqual(data['alert']['history'][1]['timeout'], 4)
         self.assertEqual(data['alert']['history'][2]['status'], 'shelved')
@@ -223,8 +197,7 @@ class ManagementTestCase(unittest.TestCase):
         response = self.client.get('/management/housekeeping', headers=self.headers)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['count'], 4)
-        self.assertListEqual(data['expired'], [expired_id])
+        self.assertEqual(data['count'], 3)
         self.assertListEqual(sorted(data['unshelve']), sorted([shelved_id, acked_and_shelved_id]))
         self.assertListEqual(sorted(data['unack']), sorted([acked_id]))
 
@@ -233,44 +206,41 @@ class ManagementTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['id'], shelved_id)
         self.assertEqual(data['alert']['status'], 'open')
-        self.assertEqual(data['alert']['timeout'], 20)
+        self.assertEqual(data['alert']['timeout'], 0)
         self.assertEqual(data['alert']['history'][0]['status'], 'open')   # previous status
-        self.assertEqual(data['alert']['history'][0]['timeout'], 20)  # previous timeout
+        self.assertEqual(data['alert']['history'][0]['timeout'], 0)  # previous timeout
         self.assertEqual(data['alert']['history'][1]['status'], 'shelved')  # status
         self.assertEqual(data['alert']['history'][1]['timeout'], 3)
         self.assertEqual(data['alert']['history'][2]['status'], 'open')
-        self.assertEqual(data['alert']['history'][2]['timeout'], 20, data['alert'])
+        self.assertEqual(data['alert']['history'][2]['timeout'], 0, data['alert'])
 
         response = self.client.get('/alert/' + acked_id)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['id'], acked_id)
         self.assertEqual(data['alert']['status'], 'open')
-        self.assertEqual(data['alert']['timeout'], 86400)
+        self.assertEqual(data['alert']['timeout'], 0)
         self.assertEqual(data['alert']['history'][0]['status'], 'open')
-        self.assertEqual(data['alert']['history'][0]['timeout'], 86400)
+        self.assertEqual(data['alert']['history'][0]['timeout'], 0)
         self.assertEqual(data['alert']['history'][1]['status'], 'ack')
         self.assertEqual(data['alert']['history'][1]['timeout'], 2)
         self.assertEqual(data['alert']['history'][2]['status'], 'open')
-        self.assertEqual(data['alert']['history'][2]['timeout'], 86400)
+        self.assertEqual(data['alert']['history'][2]['timeout'], 0)
 
         response = self.client.get('/alert/' + acked_and_shelved_id)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['id'], acked_and_shelved_id)
         self.assertEqual(data['alert']['status'], 'ack')
-        self.assertEqual(data['alert']['timeout'], 240)
+        self.assertEqual(data['alert']['timeout'], 4)
         self.assertEqual(data['alert']['history'][0]['status'], 'open')
-        self.assertEqual(data['alert']['history'][0]['timeout'], 240)
+        self.assertEqual(data['alert']['history'][0]['timeout'], 0)
         self.assertEqual(data['alert']['history'][1]['status'], 'ack')
         self.assertEqual(data['alert']['history'][1]['timeout'], 4)
         self.assertEqual(data['alert']['history'][2]['status'], 'shelved')
         self.assertEqual(data['alert']['history'][2]['timeout'], 3)
         self.assertEqual(data['alert']['history'][3]['status'], 'ack')
         self.assertEqual(data['alert']['history'][3]['timeout'], 4)
-
-        response = self.client.get('/alert/' + info_id)
-        self.assertEqual(response.status_code, 404)
 
         time.sleep(5)
 
@@ -279,26 +249,21 @@ class ManagementTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['count'], 1)
-        self.assertListEqual(data['expired'], [])
         self.assertListEqual(data['unshelve'], [])
         self.assertListEqual(data['unack'], [acked_and_shelved_id])
-
-        response = self.client.get('/alert/' + expired_id)
-        self.assertEqual(response.status_code, 404)
 
         # run housekeeping (3rd time)
         response = self.client.get('/management/housekeeping', headers=self.headers)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['count'], 0)
-        self.assertListEqual(data['expired'], [])
         self.assertListEqual(data['unshelve'], [])
         self.assertListEqual(data['unack'], [])
 
     def test_status(self):
 
         # create alert
-        response = self.client.post('/alert', data=json.dumps(self.expired_alert), headers=self.headers)
+        response = self.client.post('/alert', data=json.dumps(self.alert), headers=self.headers)
         self.assertEqual(response.status_code, 201)
 
         response = self.client.get('/management/status', headers=self.headers)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -590,7 +590,6 @@ class QueryParserTestCase(unittest.TestCase):
         test_config = {
             'TESTING': True,
             'AUTH_REQUIRED': False,
-            'ALERT_TIMEOUT': 120,
             'HISTORY_LIMIT': 5,
             'DEBUG': False,
         }
@@ -607,12 +606,11 @@ class QueryParserTestCase(unittest.TestCase):
                 'status': 'open',
                 'service': ['Network', 'Core'],
                 'group': 'Network',
-                'value': 'johno',
+                'value': '100',
                 'text': 'panic: this is a foo alert',
                 'tags': ['aaa', 'bbb', 'ccc'],
                 'attributes': {'region': 'EMEA', 'partition': '7.0'},
                 'origin': 'alpha',
-                'timeout': 100,
                 'rawData': ''
             },
             {
@@ -624,12 +622,11 @@ class QueryParserTestCase(unittest.TestCase):
                 'status': 'ack',
                 'service': ['Network', 'Core', 'Shared'],
                 'group': 'Network',
-                'value': 'jonathon',
+                'value': '200',
                 'text': 'Kernel Panic: this is a bar test alert',
                 'tags': ['bbb', 'ccc', 'ddd'],
                 'attributes': {'region': 'LATAM', 'partition': '72'},
                 'origin': 'bravo',
-                'timeout': 200,
                 'rawData': ''
             },
             {
@@ -641,12 +638,11 @@ class QueryParserTestCase(unittest.TestCase):
                 'status': 'closed',
                 'service': ['Network', 'Shared'],
                 'group': 'Netperf',
-                'value': 'jonathan',
+                'value': '300',
                 'text': 'kernel panic: this is a foo bar text alert',
                 'tags': ['ccc', 'ddd', 'eee'],
                 'attributes': {'region': 'APAC', 'partition': '727'},
                 'origin': 'charlie',
-                'timeout': 300,
                 'rawData': ''
             },
             {
@@ -658,12 +654,11 @@ class QueryParserTestCase(unittest.TestCase):
                 'status': 'closed',
                 'service': ['Core', 'Shared'],
                 'group': 'Performance',
-                'value': 'john',
+                'value': '400',
                 'text': 'kernel panick: this is a fu bar baz quux tests alert (i have a boat)',
                 'tags': ['ddd', 'eee', 'aaa'],
                 'attributes': {'region': 'EMEA', 'partition': '27'},
                 'origin': 'delta',
-                'timeout': 400,
                 'rawData': ''
             },
             {
@@ -675,12 +670,11 @@ class QueryParserTestCase(unittest.TestCase):
                 'status': 'shelved',
                 'service': ['Network', 'Core', 'Shared'],
                 'group': 'Network',
-                'value': 'jon',
+                'value': '500',
                 'text': 'don\'t panic: this is a foo bar baz quux tester alert (i have a moat)',
                 'tags': ['eee', 'aaa', 'bbb'],
                 'attributes': {},
                 'origin': 'zulu',
-                'timeout': 500,
                 'rawData': ''
             },
         ]
@@ -737,20 +731,19 @@ class QueryParserTestCase(unittest.TestCase):
 
     def test_regex(self):
         self.assertEqual(self._search(q='/[mb]oat/'), 2)
-        self.assertEqual(self._search(q='value:/joh?n(ath[oa]n)/'), 2)
         self.assertEqual(self._search(q='resource:/net(wo?rk)?[0-9]/'), 5)
         self.assertEqual(self._search(q='/f(oo|u) ba.?/'), 3)
 
     def test_ranges(self):
-        self.assertEqual(self._search(q='timeout:[100 TO 500]'), 5)
+        self.assertEqual(self._search(q='value:[100 TO 500]'), 5)
         self.assertEqual(self._search(q='origin:{alpha TO zulu}'), 3)
-        self.assertEqual(self._search(q='timeout:{* TO 300}'), 2)
-        self.assertEqual(self._search(q='timeout:[500 TO *]'), 1)
+        self.assertEqual(self._search(q='value:{* TO 300}'), 2)
+        self.assertEqual(self._search(q='value:[500 TO *]'), 1)
 
-        self.assertEqual(self._search(q='timeout:>500'), 0)
-        self.assertEqual(self._search(q='timeout:>=500'), 1)
-        self.assertEqual(self._search(q='timeout:<500'), 4)
-        self.assertEqual(self._search(q='timeout:<=500'), 5)
+        self.assertEqual(self._search(q='value:>500'), 0)
+        self.assertEqual(self._search(q='value:>=500'), 1)
+        self.assertEqual(self._search(q='value:<500'), 4)
+        self.assertEqual(self._search(q='value:<=500'), 5)
 
     def test_boolean_operators(self):
         self.assertEqual(self._search(q='"foo bar" foo'), 3)

--- a/tests/test_shelving.py
+++ b/tests/test_shelving.py
@@ -13,7 +13,6 @@ class ShelvingTestCase(unittest.TestCase):
             'AUTH_REQUIRED': True,
             'CUSTOMER_VIEWS': True,
             'PLUGINS': ['timeout'],
-            'ALERT_TIMEOUT': 24680,
             'ACK_TIMEOUT': 98765,
             'SHELVE_TIMEOUT': 12345
         }

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -871,7 +871,7 @@ class WebhooksTestCase(unittest.TestCase):
                              'target="_blank">Rule</a>')
             self.assertNotIn('service', data['alert']['attributes'])
             self.assertEqual(data['alert']['origin'], 'Grafana')
-            self.assertEqual(data['alert']['timeout'], 86400)
+            self.assertEqual(data['alert']['timeout'], 0)
             self.assertEqual(data['alert']['customer'], 'Foo Corp.')
 
     def test_graylog_webhook(self):
@@ -977,7 +977,7 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['event'], 'thing_dead')
         self.assertEqual(data['alert']['status'], 'open')
         self.assertEqual(data['alert']['severity'], 'critical')
-        self.assertEqual(data['alert']['timeout'], 86400)
+        self.assertEqual(data['alert']['timeout'], 0)
         self.assertEqual(data['alert']['attributes']['ip'], '10.1.1.1')
         self.assertEqual(data['alert']['attributes']['moreInfo'],
                          '<a href="http://somehost:9090/graph?g0.expr=sum%28irate%28messages_received_total%5B5m%5D%29%29+%3D%3D+0&g0.tab=0" target="_blank">Prometheus Graph</a>')


### PR DESCRIPTION
**Description**
Remove expired from Alerta and add correct handling of ack/shelved timeout.

**Changes**
- add update of alert timeout when sending ack/shelve action
- remove the update of the alert timeout when sending an update of the alert
- remove expire status and remove timeout used for expire (timeout is now only used for auto-unack and auto-unshelve)
- remove expired from housekeeping
- set default setting for shelve timeout to 0 (deactivated)