### PR TITLE
feat: remove repeat-type and use and function for all fields

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1963,14 +1963,11 @@ class Backend(Database):
             SELECT *
             FROM on_calls
             WHERE ((start_time IS NULL OR start_time <= %(time)s) AND (end_time IS NULL OR end_time > %(time)s))
+            AND ((start_date IS NULL OR start_date <= %(date)s) AND (end_date IS NULL OR end_date >= %(date)s))
             AND (
-              (start_date = %(date)s) OR (start_date < %(date)s AND end_date >= %(date)s)
-              OR (
-                repeat_type = 'list'
-                AND (repeat_days IS NULL OR repeat_days='{}' OR ARRAY[%(day)s] <@ repeat_days)
+                (repeat_days IS NULL OR repeat_days='{}' OR ARRAY[%(day)s] <@ repeat_days)
                 AND (repeat_weeks IS NULL OR repeat_weeks='{}' OR ARRAY[%(week)s] <@ repeat_weeks)
                 AND (repeat_months IS NULL OR repeat_months='{}' OR ARRAY[%(month)s] <@ repeat_months)
-              )
             )
 
         """


### PR DESCRIPTION
**Description**
Change on-calls from checking the time and date, or the repeat-list, to always checking the repeat-list and date

**Changes**
- remove check of repeat-type for active on-calls
- change or function to and function between date and repeat list for active on-calls
- add null checks for the start date and end date for active on-calls